### PR TITLE
bug fixes for generating transfer classes and factories

### DIFF
--- a/packages/application/bin/console
+++ b/packages/application/bin/console
@@ -1,18 +1,15 @@
 #!/usr/bin/env php
 <?php
 
-use Jellyfish\Kernel\Kernel;
-use Jellyfish\Application\Console;
-
-$rootDir = __DIR__ . '/../../../..';
+$rootDir = \realpath(__DIR__ . '/../../../..');
 
 if (!\file_exists($rootDir . '/vendor/autoload.php')) {
-    $rootDir = __DIR__ . '/../../../../../..';
+    $rootDir = \realpath(__DIR__ . '/../../../../../..');
 }
 
 require_once $rootDir . '/vendor/autoload.php';
 
-$kernel = new Kernel($rootDir);
-$application = new Console($kernel);
+$kernel = new \Jellyfish\Kernel\Kernel($rootDir);
+$application = new \Jellyfish\Application\Console($kernel);
 
 $application->run();

--- a/packages/finder-symfony/src/Jellyfish/FinderSymfony/Finder.php
+++ b/packages/finder-symfony/src/Jellyfish/FinderSymfony/Finder.php
@@ -46,6 +46,18 @@ class Finder implements FinderInterface
     }
 
     /**
+     * @param int $level
+     *
+     * @return \Jellyfish\Finder\FinderInterface
+     */
+    public function depth(int $level): FinderInterface
+    {
+        $this->symfonyFinder->depth($level);
+
+        return $this;
+    }
+
+    /**
      * @return \Iterator
      */
     public function getIterator(): Iterator

--- a/packages/finder-symfony/tests/Jellyfish/FinderSymfony/FinderTest.php
+++ b/packages/finder-symfony/tests/Jellyfish/FinderSymfony/FinderTest.php
@@ -74,6 +74,21 @@ class FinderTest extends Unit
     /**
      * @return void
      */
+    public function testDepth(): void
+    {
+        $level = 0;
+
+        $this->symfonyFinderMock->expects($this->atLeastOnce())
+            ->method('depth')
+            ->with($level)
+            ->willReturn($this->symfonyFinderMock);
+
+        $this->assertEquals($this->finder, $this->finder->depth($level));
+    }
+
+    /**
+     * @return void
+     */
     public function testGetIterator(): void
     {
         $this->symfonyFinderMock->expects($this->atLeastOnce())

--- a/packages/finder/src/Jellyfish/Finder/FinderInterface.php
+++ b/packages/finder/src/Jellyfish/Finder/FinderInterface.php
@@ -22,6 +22,13 @@ interface FinderInterface extends IteratorAggregate
     public function name(string $pattern): FinderInterface;
 
     /**
+     * @param int $level
+     *
+     * @return \Jellyfish\Finder\FinderInterface
+     */
+    public function depth(int $level): FinderInterface;
+
+    /**
      * @return \Iterator
      */
     public function getIterator(): Iterator;

--- a/packages/transfer/src/Jellyfish/Transfer/Definition/ClassDefinition.php
+++ b/packages/transfer/src/Jellyfish/Transfer/Definition/ClassDefinition.php
@@ -19,7 +19,7 @@ class ClassDefinition implements ClassDefinitionInterface
     protected $namespace;
 
     /**
-     * @var \Jellyfish\Transfer\Definition\ClassPropertyDefinitionInterface[]
+     * @var \Jellyfish\Transfer\Definition\ClassPropertyDefinition[]
      */
     protected $properties;
 

--- a/packages/transfer/src/Jellyfish/Transfer/Templates/adder.twig
+++ b/packages/transfer/src/Jellyfish/Transfer/Templates/adder.twig
@@ -1,11 +1,25 @@
-
-    {# Adder #}
+{% set atParamTag %}
+    {%- if not property.isPrimitive() -%}
+        {{ '\\' ~ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') ~ '\\' }}
+        {%- if property.getTypeNamespace() is defined and property.getTypeNamespace() is not null -%}
+            {{ property.getTypeNamespace() ~ '\\'}}
+        {%- endif %}
+    {%- endif %}
+    {{- property.getType() -}}
+{% endset %}
+{% set atReturnTag %}
+    {{- '\\' ~ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') ~ '\\' -}}
+    {%- if classDefinition.getNamespace() is defined and classDefinition.getNamespace() is not null -%}
+        {{ classDefinition.getNamespace() ~ '\\' }}
+    {%- endif %}
+    {{- classDefinition.getName() -}}
+{% endset %}
     /**
-     * @param @param {% if not property.isPrimitive() %}\{{ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') }}\{% if property.getTypeNamespace() is defined %}{{ property.getTypeNamespace() }}\{% endif %}{% endif %}{{ property.getType() }} ${{ property.getSingular() }}
+     * @param {{ atParamTag }} ${{ property.getSingular() }}
      *
-     * @return \{{ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') }}\{% if classDefinition.getNamespace() is defined %}{{ classDefinition.getNamespace() }}\{% endif %}{{ classDefinition.getName() }}
+     * @return {{ atReturnTag }}
      */
-    public function add{{ property.getSingular() | capitalize }}({{ property.getType() }} ${{ property.getSingular() }}): {{ classDefinition.getName() }}
+    public function add{{ property.getSingular()[:1] | upper ~ property.getSingular()[1:] }}({{ property.getType() }} ${{ property.getSingular() }}): {{ classDefinition.getName() }}
     {
         $this->{{ property.getName() }}[] = ${{ property.getSingular() }};
 

--- a/packages/transfer/src/Jellyfish/Transfer/Templates/class.twig
+++ b/packages/transfer/src/Jellyfish/Transfer/Templates/class.twig
@@ -1,12 +1,8 @@
-{% set useBlock = include('use-block.twig') with {classDefinition: classDefinition} only %}
 <?php
 
-namespace {{ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') }}{% if classDefinition.getNamespace() is defined %}\{{ classDefinition.getNamespace() }};{% endif %}
-{% if useBlock != '' %}
+{% include('namespace.twig') with { classDefinition: classDefinition } only %}
 
-{{ useBlock }}
-{% endif %}
-
+{% include('use-statements.twig') with { classDefinition: classDefinition } only %}
 class {{ classDefinition.getName() }}
 {
 {% for property in classDefinition.getProperties() %}
@@ -14,12 +10,18 @@ class {{ classDefinition.getName() }}
 
 {% endif %}
 {% include('property.twig') with {property: property} only %}
+{% if loop.last %}
+
+{% endif %}
 {% endfor %}
 {% for property in classDefinition.getProperties() %}
 {% include('getter.twig') with {property: property} only %}
+
 {% include('setter.twig') with {property: property, classDefinition: classDefinition} only %}
 {% if property.isArray() %}
+
 {% include('adder.twig') with {property: property, classDefinition: classDefinition} only %}
+
 {% endif %}
 {% if not loop.last %}
 

--- a/packages/transfer/src/Jellyfish/Transfer/Templates/factory-class.twig
+++ b/packages/transfer/src/Jellyfish/Transfer/Templates/factory-class.twig
@@ -1,11 +1,18 @@
+{% set atReturnTag %}
+    {{- '\\' ~ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') ~ '\\' -}}
+    {%- if classDefinition.getNamespace() is defined and classDefinition.getNamespace() is not null -%}
+        {{ classDefinition.getNamespace() ~ '\\' }}
+    {%- endif %}
+    {{- classDefinition.getName() -}}
+{% endset %}
 <?php
 
-namespace {{ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') }}{% if classDefinition.getNamespace() is defined %}\{{ classDefinition.getNamespace() }}{% endif %};
+{% include('namespace.twig') with { classDefinition: classDefinition } only %}
 
 class {{ classDefinition.getName() }}{{ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::FACTORY_NAME_SUFFIX') }}
 {
     /**
-     * @return \{{ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') }}\{% if classDefinition.getNamespace() is defined %}{{ classDefinition.getNamespace() }}\{% endif %}{{ classDefinition.getName() }}
+     * @return {{ atReturnTag }}
      */
     public function create(): {{ classDefinition.getName() }}
     {

--- a/packages/transfer/src/Jellyfish/Transfer/Templates/factory-registry.twig
+++ b/packages/transfer/src/Jellyfish/Transfer/Templates/factory-registry.twig
@@ -1,14 +1,22 @@
 <?php
+{% if classDefinitionMap|length > 0 %}
 
+{% endif %}
 {% for classDefinition in classDefinitionMap %}
-    use {{ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') }}\{% if classDefinition.getNamespace() is defined %}{{ classDefinition.getNamespace() }}\{% endif %}{{ classDefinition.getName() }};
-    {% if loop.last %}
-
-    {% endif %}
+    {{- 'use ' ~ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') ~ '\\' -}}
+    {%- if classDefinition.getNamespace() is defined and classDefinition.getNamespace() is not null -%}
+        {{ classDefinition.getNamespace() ~ '\\' }}
+    {%- endif %}
+    {{- classDefinition.getName() ~ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::FACTORY_NAME_SUFFIX') ~ ';' }}
 {% endfor %}
-{% for classDefinition in classDefinitionMap %}
-    $factoryRegistry[{{ classDefinition.getId() }}_factory] = new {{ classDefinition.getName() }}{{ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::FACTORY_NAME_SUFFIX') }}();
-    {% if loop.last %}
+{% if classDefinitionMap|length > 0 %}
 
-    {% endif %}
+{% endif %}
+{% for classDefinition in classDefinitionMap %}
+    {{- "$factoryRegistry['" -}}
+    {{- classDefinition.getId() -}}
+    {{- "_factory'] = new " -}}
+    {{- classDefinition.getName() -}}
+    {{- constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::FACTORY_NAME_SUFFIX') -}}
+    {{- '();' }}
 {% endfor %}

--- a/packages/transfer/src/Jellyfish/Transfer/Templates/getter.twig
+++ b/packages/transfer/src/Jellyfish/Transfer/Templates/getter.twig
@@ -1,8 +1,32 @@
-    {# Getter #}
+{% set atReturnTag %}
+    {%- if not property.isPrimitive() -%}
+        {{ '\\' ~ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') ~ '\\' }}
+        {%- if property.getTypeNamespace() is defined and property.getTypeNamespace() is not null -%}
+            {{ property.getTypeNamespace() ~ '\\' }}
+        {%- endif %}
+    {%- endif %}
+    {{- property.getType() -}}
+    {%- if property.isArray() -%}
+        []
+    {%- endif %}
+    {%- if property.isNullable() -%}
+        |null
+    {%- endif %}
+{% endset %}
+{% set returnType %}
+    {%- if property.isNullable() -%}
+        ?
+    {%- endif %}
+    {%- if property.isArray() -%}
+        array
+    {%- else -%}
+        {{ property.getType() }}
+    {%- endif %}
+{% endset %}
     /**
-    * @return {% if not property.isPrimitive() %}\{{ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') }}\{% if property.getTypeNamespace() is defined %}{{ property.getTypeNamespace() }}\{% endif %}{% endif %}{{ property.getType() }}{% if property.isArray() %}[]{% endif %}{% if property.isNullable() %}|null{% endif %}
-    */
-    public function get{{ property.getName() | capitalize }}(): {% if property.isNullable() %}?{% endif %}{% if property.isArray() %}array{% else %}{{ property.getType() }}{% endif %}
+     * @return {{ atReturnTag }}
+     */
+    public function get{{ property.getName()[:1]|upper ~ property.getName()[1:] }}(): {{ returnType }}
     {
         return $this->{{ property.getName() }};
     }

--- a/packages/transfer/src/Jellyfish/Transfer/Templates/namespace.twig
+++ b/packages/transfer/src/Jellyfish/Transfer/Templates/namespace.twig
@@ -1,0 +1,7 @@
+{% set namespace %}
+    {{- constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') -}}
+    {%- if classDefinition.getNamespace() is defined and classDefinition.getNamespace() is not null-%}
+        {{ '\\' ~ classDefinition.getNamespace() }}
+    {%- endif %}
+{% endset %}
+namespace {{ namespace }};

--- a/packages/transfer/src/Jellyfish/Transfer/Templates/property.twig
+++ b/packages/transfer/src/Jellyfish/Transfer/Templates/property.twig
@@ -1,4 +1,19 @@
+{% set atVarTag %}
+    {%- if not property.isPrimitive() -%}
+        {{ '\\' ~ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') ~ '\\' }}
+        {%- if property.getTypeNamespace() is defined and property.getTypeNamespace() is not null-%}
+            {{ property.getTypeNamespace() ~ '\\' }}
+        {%- endif %}
+    {%- endif %}
+    {{- property.getType() -}}
+    {%- if property.isArray() -%}
+        []
+    {%- endif %}
+    {%- if property.isNullable() -%}
+        |null
+    {%- endif %}
+{% endset %}
     /**
-     * @var {% if not property.isPrimitive() %}\{{ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') }}\{% if property.getTypeNamespace() is defined %}{{ property.getTypeNamespace() }}\{% endif %}{% endif %}{{ property.getType() }}{% if property.isArray() %}[]{% endif %}{% if property.isNullable() %}|null{% endif %} ${{ property.getName }}
+     * @var {{ atVarTag }} ${{ property.getName }}
      */
     protected ${{ property.getName }};

--- a/packages/transfer/src/Jellyfish/Transfer/Templates/setter.twig
+++ b/packages/transfer/src/Jellyfish/Transfer/Templates/setter.twig
@@ -1,10 +1,31 @@
-    {# Setter #}
+{% set atParamTag %}
+    {%- if not property.isPrimitive() -%}
+        {{ '\\' ~ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') ~ '\\' }}
+        {%- if property.getTypeNamespace() is defined and property.getTypeNamespace() is not null -%}
+            {{ property.getTypeNamespace() ~ '\\' }}
+        {%- endif %}
+    {%- endif %}
+    {{- property.getType() -}}
+    {%- if property.isArray() -%}
+        []
+    {%- endif %}
+    {%- if property.isNullable() -%}
+        |null
+    {%- endif %}
+{% endset %}
+{% set atReturnTag %}
+    {{- '\\' ~ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') ~ '\\' -}}
+    {%- if classDefinition.getNamespace() is defined and classDefinition.getNamespace() is not null -%}
+        {{ classDefinition.getNamespace() ~ '\\' }}
+    {%- endif %}
+    {{- classDefinition.getName() -}}
+{% endset %}
     /**
-     * @param {% if not property.isPrimitive() %}\{{ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') }}\{% if property.getTypeNamespace() is defined %}{{ property.getTypeNamespace() }}\{% endif %}{% endif %}{{ property.getType() }}{% if property.isArray() %}[]{% endif %}{% if property.isNullable() %}|null{% endif %} ${{ property.getName() }}
+     * @param {{ atParamTag }} ${{ property.getName() }}
      *
-     * @return \{{ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') }}\{% if classDefinition.getNamespace() is defined %}{{ classDefinition.getNamespace() }}\{% endif %}{{ classDefinition.getName() }}
+     * @return {{ atReturnTag }}
      */
-    public function set{{ property.getName() | capitalize }}({% if property.isNullable() %}?{% endif %}{% if property.isArray() %}array{% else %}{{ property.getType() }}{% endif %} ${{ property.getName() }}): {{ classDefinition.getName() }}
+    public function set{{ property.getName()[:1]|upper ~ property.getName()[1:] }}({% if property.isNullable() %}?{% endif %}{% if property.isArray() %}array{% else %}{{ property.getType() }}{% endif %} ${{ property.getName() }}): {{ classDefinition.getName() }}
     {
         $this->{{ property.getName() }} = ${{ property.getName() }};
 

--- a/packages/transfer/src/Jellyfish/Transfer/Templates/use-block.twig
+++ b/packages/transfer/src/Jellyfish/Transfer/Templates/use-block.twig
@@ -1,5 +1,0 @@
-{% for property in classDefinition.getProperties() %}
-{% if not property.isPrimitive() and not property.isArray() and property.getTypeNamespace() != classDefinition.getNamespace() %}
-use {{ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') }}\{% if property.getTypeNamespace() is defined %}{{ property.getTypeNamespace() }}\{% endif %}{{ property.getType() }};
-{% endif %}
-{% endfor %}

--- a/packages/transfer/src/Jellyfish/Transfer/Templates/use-statements.twig
+++ b/packages/transfer/src/Jellyfish/Transfer/Templates/use-statements.twig
@@ -1,0 +1,17 @@
+{% set useStatements = [] %}
+{% for property in classDefinition.getProperties() -%}
+    {%- if not property.isPrimitive() and not property.isArray() and property.getTypeNamespace() != classDefinition.getNamespace() -%}
+        {% set useStatement = 'use ' ~  constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') ~ '\\' %}
+        {%- if property.getTypeNamespace() is defined and property.getTypeNamespace() is not null -%}
+            {% set useStatement = useStatement ~ property.getTypeNamespace() ~ '\\' %}
+        {%- endif %}
+        {%- set useStatement = useStatement ~ property.getType() ~ ';' -%}
+        {%- set useStatements = useStatements|merge([useStatement]) -%}
+    {%- endif %}
+{%- endfor %}
+{% for useStatement in useStatements %}
+    {{- useStatement }}
+{% endfor %}
+{% if useStatements|length > 0 %}
+
+{% endif %}

--- a/packages/transfer/src/Jellyfish/Transfer/TransferGenerator.php
+++ b/packages/transfer/src/Jellyfish/Transfer/TransferGenerator.php
@@ -3,6 +3,7 @@
 namespace Jellyfish\Transfer;
 
 use Jellyfish\Transfer\Definition\ClassDefinitionMapLoaderInterface;
+use Jellyfish\Transfer\Generator\FactoryRegistryGeneratorInterface;
 
 class TransferGenerator implements TransferGeneratorInterface
 {
@@ -17,14 +18,22 @@ class TransferGenerator implements TransferGeneratorInterface
     protected $classGenerators;
 
     /**
+     * @var \Jellyfish\Transfer\Generator\FactoryRegistryGeneratorInterface
+     */
+    protected $factoryRegistryGenerator;
+
+    /**
      * @param \Jellyfish\Transfer\Definition\ClassDefinitionMapLoaderInterface $classDefinitionMapLoader
+     * @param \Jellyfish\Transfer\Generator\FactoryRegistryGeneratorInterface $factoryRegistryGenerator
      * @param \Jellyfish\Transfer\Generator\ClassGeneratorInterface[] $classGenerators
      */
     public function __construct(
         ClassDefinitionMapLoaderInterface $classDefinitionMapLoader,
+        FactoryRegistryGeneratorInterface $factoryRegistryGenerator,
         array $classGenerators
     ) {
         $this->classDefinitionMapLoader = $classDefinitionMapLoader;
+        $this->factoryRegistryGenerator = $factoryRegistryGenerator;
         $this->classGenerators = $classGenerators;
     }
 
@@ -40,6 +49,8 @@ class TransferGenerator implements TransferGeneratorInterface
                 $classGenerator->generate($classDefinitionMapEntry);
             }
         }
+
+        $this->factoryRegistryGenerator->generate($classDefinitionMap);
 
         return $this;
     }

--- a/packages/transfer/tests/Jellyfish/Transfer/TransferGeneratorTest.php
+++ b/packages/transfer/tests/Jellyfish/Transfer/TransferGeneratorTest.php
@@ -6,6 +6,7 @@ use Codeception\Test\Unit;
 use Jellyfish\Transfer\Generator\ClassGeneratorInterface;
 use Jellyfish\Transfer\Definition\ClassDefinitionInterface;
 use Jellyfish\Transfer\Definition\ClassDefinitionMapLoaderInterface;
+use Jellyfish\Transfer\Generator\FactoryRegistryGeneratorInterface;
 
 class TransferGeneratorTest extends Unit
 {
@@ -18,6 +19,11 @@ class TransferGeneratorTest extends Unit
      * @var \Jellyfish\Transfer\Definition\ClassDefinitionMapLoaderInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $classDefinitionMapLoaderMock;
+
+    /**
+     * @var \Jellyfish\Transfer\Generator\FactoryRegistryGeneratorInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $factoryRegistryGeneratorMock;
 
     /**
      * @var \Jellyfish\Transfer\Generator\ClassGeneratorInterface[]|\PHPUnit\Framework\MockObject\MockObject[]
@@ -46,6 +52,10 @@ class TransferGeneratorTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->factoryRegistryGeneratorMock = $this->getMockBuilder(FactoryRegistryGeneratorInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->classGeneratorMocks = [
             $this->getMockBuilder(ClassGeneratorInterface::class)
                 ->disableOriginalConstructor()
@@ -54,6 +64,7 @@ class TransferGeneratorTest extends Unit
 
         $this->transferGenerator = new TransferGenerator(
             $this->classDefinitionMapLoaderMock,
+            $this->factoryRegistryGeneratorMock,
             $this->classGeneratorMocks
         );
     }
@@ -71,6 +82,11 @@ class TransferGeneratorTest extends Unit
             ->method('generate')
             ->with($this->classDefinitionMapMock[0])
             ->willReturn($this->classGeneratorMocks[0]);
+
+        $this->factoryRegistryGeneratorMock->expects($this->atLeastOnce())
+            ->method('generate')
+            ->with($this->classDefinitionMapMock)
+            ->willReturn($this->factoryRegistryGeneratorMock);
 
         $this->assertEquals(
             $this->transferGenerator,


### PR DESCRIPTION
- use realpath for root directory
- add depth method to finder
- cleanup twig templates
- add factory registry generator to transfer generator
- don't remove factory registry by transfer cleaner