### PR TITLE
Fixes for transfer and symfony process bundle

### DIFF
--- a/packages/process-symfony/src/Jellyfish/ProcessSymfony/Process.php
+++ b/packages/process-symfony/src/Jellyfish/ProcessSymfony/Process.php
@@ -23,9 +23,7 @@ class Process implements ProcessInterface
     public function __construct(array $command)
     {
         $this->command = $command;
-        $preparedCommand = \implode(' ', $this->command);
-
-        $this->process = new SymfonyProcess($preparedCommand);
+        $this->process = new SymfonyProcess($command);
     }
 
     /**

--- a/packages/transfer/src/Jellyfish/Transfer/Definition/ClassDefinitionInterface.php
+++ b/packages/transfer/src/Jellyfish/Transfer/Definition/ClassDefinitionInterface.php
@@ -34,6 +34,16 @@ interface ClassDefinitionInterface
     public function setNamespace(?string $namespace): ClassDefinitionInterface;
 
     /**
+     * @return array
+     */
+    public function getUseStatements(): array;
+
+    /**
+     * @return string
+     */
+    public function getNamespaceStatement(): string;
+
+    /**
      * @return \Jellyfish\Transfer\Definition\ClassPropertyDefinitionInterface[]
      */
     public function getProperties(): array;

--- a/packages/transfer/src/Jellyfish/Transfer/Templates/class.twig
+++ b/packages/transfer/src/Jellyfish/Transfer/Templates/class.twig
@@ -1,8 +1,8 @@
 <?php
 
-{% include('namespace.twig') with { classDefinition: classDefinition } only %}
+{% include('namespace.twig') with { namespaceStatement: classDefinition.getNamespaceStatement() } only %}
 
-{% include('use-statements.twig') with { classDefinition: classDefinition } only %}
+{% include('use-statements.twig') with { useStatements: classDefinition.getUseStatements() } only %}
 class {{ classDefinition.getName() }}
 {
 {% for property in classDefinition.getProperties() %}

--- a/packages/transfer/src/Jellyfish/Transfer/Templates/factory-class.twig
+++ b/packages/transfer/src/Jellyfish/Transfer/Templates/factory-class.twig
@@ -7,7 +7,7 @@
 {% endset %}
 <?php
 
-{% include('namespace.twig') with { classDefinition: classDefinition } only %}
+{% include('namespace.twig') with { namespaceStatement: classDefinition.getNamespaceStatement() } only %}
 
 class {{ classDefinition.getName() }}{{ constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::FACTORY_NAME_SUFFIX') }}
 {

--- a/packages/transfer/src/Jellyfish/Transfer/Templates/namespace.twig
+++ b/packages/transfer/src/Jellyfish/Transfer/Templates/namespace.twig
@@ -1,7 +1,1 @@
-{% set namespace %}
-    {{- constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') -}}
-    {%- if classDefinition.getNamespace() is not null-%}
-        {{ '\\' ~ classDefinition.getNamespace() }}
-    {%- endif %}
-{% endset %}
-namespace {{ namespace }};
+{{ namespaceStatement }}

--- a/packages/transfer/src/Jellyfish/Transfer/Templates/use-statements.twig
+++ b/packages/transfer/src/Jellyfish/Transfer/Templates/use-statements.twig
@@ -1,19 +1,4 @@
-{% set useStatements = [] %}
-{% for property in classDefinition.getProperties() -%}
-    {%- if not property.isPrimitive() and (property.getTypeNamespace() != classDefinition.getNamespace() or property.getTypeAlias() is not null) -%}
-        {% set useStatement = 'use ' ~  constant('\\Jellyfish\\Transfer\\Definition\\ClassDefinition::NAMESPACE_PREFIX') ~ '\\' %}
-        {%- if property.getTypeNamespace() is not null -%}
-            {% set useStatement = useStatement ~ property.getTypeNamespace() ~ '\\' %}
-        {%- endif %}
-        {%- set useStatement = useStatement ~ property.getType() -%}
-        {%- if property.getTypeAlias() is not null -%}
-            {%- set useStatement = useStatement ~ ' as ' ~ property.getTypeAlias() -%}
-        {%- endif %}
-        {%- set useStatement = useStatement ~ ';' -%}
-        {%- set useStatements = useStatements|merge([useStatement]) -%}
-    {%- endif %}
-{%- endfor %}
-{% for useStatement in useStatements %}
+{% for useStatement in useStatements -%}
     {{- useStatement }}
 {% endfor %}
 {% if useStatements|length > 0 %}

--- a/packages/transfer/tests/Jellyfish/Transfer/Definition/ClassDefinitionTest.php
+++ b/packages/transfer/tests/Jellyfish/Transfer/Definition/ClassDefinitionTest.php
@@ -65,6 +65,97 @@ class ClassDefinitionTest extends Unit
     /**
      * @return void
      */
+    public function testGetNamespaceStatement(): void
+    {
+       $namespace = 'Lorem';
+       $expectedNamespaceStatement = \sprintf('namespace %s\\%s;', ClassDefinition::NAMESPACE_PREFIX, $namespace);
+
+       $this->assertEquals($this->classDefinition, $this->classDefinition->setNamespace($namespace));
+       $this->assertEquals($expectedNamespaceStatement, $this->classDefinition->getNamespaceStatement());
+
+    }
+
+    /**
+     * @return void
+     */
+    public function testUseStatements(): void
+    {
+        $propertyMocks = [
+            $this->getMockBuilder(ClassPropertyDefinitionInterface::class)
+                ->disableOriginalConstructor()
+                ->getMock(),
+            $this->getMockBuilder(ClassPropertyDefinitionInterface::class)
+                ->disableOriginalConstructor()
+                ->getMock(),
+            $this->getMockBuilder(ClassPropertyDefinitionInterface::class)
+                ->disableOriginalConstructor()
+                ->getMock(),
+            $this->getMockBuilder(ClassPropertyDefinitionInterface::class)
+                ->disableOriginalConstructor()
+                ->getMock()
+        ];
+
+        $this->assertEquals($this->classDefinition, $this->classDefinition->setNamespace('Lorem'));
+        $this->assertEquals($this->classDefinition, $this->classDefinition->setProperties($propertyMocks));
+
+        $propertyMocks[0]->expects($this->atLeastOnce())
+            ->method('isPrimitive')
+            ->willReturn(true);
+
+        $propertyMocks[1]->expects($this->atLeastOnce())
+            ->method('isPrimitive')
+            ->willReturn(false);
+
+        $propertyMocks[1]->expects($this->atLeastOnce())
+            ->method('getTypeNamespace')
+            ->willReturn('Ipsum');
+
+        $propertyMocks[1]->expects($this->atLeastOnce())
+            ->method('getTypeAlias')
+            ->willReturn(null);
+
+        $propertyMocks[1]->expects($this->atLeastOnce())
+            ->method('getType')
+            ->willReturn('A');
+
+        $propertyMocks[2]->expects($this->atLeastOnce())
+            ->method('isPrimitive')
+            ->willReturn(false);
+
+        $propertyMocks[2]->expects($this->atLeastOnce())
+            ->method('getTypeNamespace')
+            ->willReturn('Ipsum');
+
+        $propertyMocks[2]->expects($this->atLeastOnce())
+            ->method('getTypeAlias')
+            ->willReturn(null);
+
+        $propertyMocks[2]->expects($this->atLeastOnce())
+            ->method('getType')
+            ->willReturn('A');
+
+        $propertyMocks[3]->expects($this->atLeastOnce())
+            ->method('isPrimitive')
+            ->willReturn(false);
+
+        $propertyMocks[3]->expects($this->atLeastOnce())
+            ->method('getTypeNamespace')
+            ->willReturn('Lorem');
+
+        $propertyMocks[3]->expects($this->atLeastOnce())
+            ->method('getTypeAlias')
+            ->willReturn('LoremA');
+
+        $propertyMocks[3]->expects($this->atLeastOnce())
+            ->method('getType')
+            ->willReturn('A');
+
+        $this->assertCount(2, $this->classDefinition->getUseStatements());
+    }
+
+    /**
+     * @return void
+     */
     public function testSetAndGetProperties(): void
     {
         $propertyMocks = [


### PR DESCRIPTION
- add only one use statement for any transfer class
- remove logic from twig
- use array instead of string for symfony process