### PR TITLE
allow micro service architecture

### DIFF
--- a/packages/config/src/Jellyfish/Config/ConfigServiceProvider.php
+++ b/packages/config/src/Jellyfish/Config/ConfigServiceProvider.php
@@ -9,6 +9,8 @@ use Pimple\ServiceProviderInterface;
 
 class ConfigServiceProvider implements ServiceProviderInterface
 {
+    public const CONTAINER_KEY_CONFIG = 'config';
+
     /**
      * @param \Pimple\Container $pimple
      *
@@ -18,7 +20,7 @@ class ConfigServiceProvider implements ServiceProviderInterface
     {
         $self = $this;
 
-        $pimple->offsetSet('config', static function (Container $container) use ($self) {
+        $pimple->offsetSet(static::CONTAINER_KEY_CONFIG, static function (Container $container) use ($self) {
             return $self->createConfig($container);
         });
     }

--- a/packages/event/src/Jellyfish/Event/EventDispatcher.php
+++ b/packages/event/src/Jellyfish/Event/EventDispatcher.php
@@ -68,14 +68,7 @@ class EventDispatcher implements EventDispatcherInterface
      */
     protected function dispatchAsync(EventInterface $event): EventDispatcherInterface
     {
-        $listeners = $this->eventListenerProvider->getListenersByTypeAndEventName(
-            EventListenerInterface::TYPE_ASYNC,
-            $event->getName()
-        );
-
-        foreach ($listeners as $listener) {
-            $this->eventQueueProducer->enqueue($event, $listener);
-        }
+        $this->eventQueueProducer->enqueue($event);
 
         return $this;
     }

--- a/packages/event/src/Jellyfish/Event/EventQueueProducer.php
+++ b/packages/event/src/Jellyfish/Event/EventQueueProducer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Jellyfish\Event;
 
+use Jellyfish\Queue\DestinationFactoryInterface;
+use Jellyfish\Queue\DestinationInterface;
 use Jellyfish\Queue\QueueClientInterface;
 
 class EventQueueProducer implements EventQueueProducerInterface
@@ -19,39 +21,40 @@ class EventQueueProducer implements EventQueueProducerInterface
     protected $queueClient;
 
     /**
-     * @var \Jellyfish\Event\EventQueueNameGeneratorInterface
+     * @var \Jellyfish\Queue\DestinationFactoryInterface
      */
-    protected $eventQueueNameGenerator;
+    protected $destinationFactory;
 
     /**
      * @param \Jellyfish\Event\EventMapperInterface $eventMapper
-     * @param \Jellyfish\Event\EventQueueNameGeneratorInterface $eventQueueNameGenerator
      * @param \Jellyfish\Queue\QueueClientInterface $queueClient
+     * @param \Jellyfish\Queue\DestinationFactoryInterface $destinationFactory
      */
     public function __construct(
         EventMapperInterface $eventMapper,
-        EventQueueNameGeneratorInterface $eventQueueNameGenerator,
-        QueueClientInterface $queueClient
+        QueueClientInterface $queueClient,
+        DestinationFactoryInterface $destinationFactory
     ) {
         $this->eventMapper = $eventMapper;
-        $this->eventQueueNameGenerator = $eventQueueNameGenerator;
         $this->queueClient = $queueClient;
+        $this->destinationFactory = $destinationFactory;
     }
 
     /**
      * @param \Jellyfish\Event\EventInterface $event
-     * @param \Jellyfish\Event\EventListenerInterface $listener
      *
      * @return \Jellyfish\Event\EventQueueProducerInterface
      */
     public function enqueue(
-        EventInterface $event,
-        EventListenerInterface $listener
+        EventInterface $event
     ): EventQueueProducerInterface {
-        $eventQueueName = $this->eventQueueNameGenerator->generate($event->getName(), $listener->getIdentifier());
+        $destination = $this->destinationFactory->create()
+            ->setName($event->getName())
+            ->setType(DestinationInterface::TYPE_FANOUT);
+
         $message = $this->eventMapper->toMessage($event);
 
-        $this->queueClient->sendMessage($eventQueueName, $message);
+        $this->queueClient->sendMessage($destination, $message);
 
         return $this;
     }

--- a/packages/event/src/Jellyfish/Event/EventQueueProducerInterface.php
+++ b/packages/event/src/Jellyfish/Event/EventQueueProducerInterface.php
@@ -8,12 +8,10 @@ interface EventQueueProducerInterface
 {
     /**
      * @param \Jellyfish\Event\EventInterface $event
-     * @param \Jellyfish\Event\EventListenerInterface $listener
      *
      * @return \Jellyfish\Event\EventQueueProducerInterface
      */
     public function enqueue(
-        EventInterface $event,
-        EventListenerInterface $listener
+        EventInterface $event
     ): EventQueueProducerInterface;
 }

--- a/packages/event/src/Jellyfish/Event/EventServiceProvider.php
+++ b/packages/event/src/Jellyfish/Event/EventServiceProvider.php
@@ -6,6 +6,7 @@ namespace Jellyfish\Event;
 
 use Jellyfish\Event\Command\EventQueueConsumeCommand;
 use Jellyfish\Event\Command\EventQueueWorkerStartCommand;
+use Jellyfish\Queue\QueueServiceProvider;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
@@ -92,8 +93,8 @@ class EventServiceProvider implements ServiceProviderInterface
         if ($this->eventQueueProducer === null) {
             $this->eventQueueProducer = new EventQueueProducer(
                 $this->createEventMapper($container),
-                $this->createEventQueueNameGenerator(),
-                $container->offsetGet('queue_client')
+                $container->offsetGet(QueueServiceProvider::CONTAINER_KEY_QUEUE_CLIENT),
+                $container->offsetGet(QueueServiceProvider::CONTAINER_KEY_DESTINATION_FACTORY)
             );
         }
 
@@ -112,7 +113,8 @@ class EventServiceProvider implements ServiceProviderInterface
                 $container->offsetGet('process_factory'),
                 $this->createEventMapper($container),
                 $this->createEventQueueNameGenerator(),
-                $container->offsetGet('queue_client'),
+                $container->offsetGet(QueueServiceProvider::CONTAINER_KEY_QUEUE_CLIENT),
+                $container->offsetGet(QueueServiceProvider::CONTAINER_KEY_DESTINATION_FACTORY),
                 $container->offsetGet('root_dir')
             );
         }

--- a/packages/event/tests/Jellyfish/Event/EventDispatcherTest.php
+++ b/packages/event/tests/Jellyfish/Event/EventDispatcherTest.php
@@ -124,25 +124,11 @@ class EventDispatcherTest extends Unit
      */
     public function testDispatchAsyncListeners(): void
     {
-        $this->eventMock->expects($this->atLeastOnce())
-            ->method('getName')
-            ->willReturn($this->eventName);
-
-        $this->eventListenerProviderMock->expects($this->atLeastOnce())
-            ->method('getListenersByTypeAndEventName')
-            ->withConsecutive([
-                EventListenerInterface::TYPE_SYNC,
-                $this->eventName
-            ], [
-                EventListenerInterface::TYPE_ASYNC,
-                $this->eventName
-            ])->willReturnOnConsecutiveCalls([], [$this->eventListenerMock]);
-
-        $this->eventQueueProducerMock->expects($this->atLeastOnce())
+        $this->eventQueueProducerMock->expects(self::atLeastOnce())
             ->method('enqueue')
-            ->with($this->eventMock, $this->eventListenerMock);
+            ->with($this->eventMock);
 
-        $this->assertEquals(
+        self::assertEquals(
             $this->eventDispatcher,
             $this->eventDispatcher->dispatch($this->eventMock)
         );

--- a/packages/event/tests/Jellyfish/Event/EventServiceProviderTest.php
+++ b/packages/event/tests/Jellyfish/Event/EventServiceProviderTest.php
@@ -8,9 +8,12 @@ use Codeception\Test\Unit;
 use Jellyfish\Event\Command\EventQueueConsumeCommand;
 use Jellyfish\Event\Command\EventQueueWorkerStartCommand;
 use Jellyfish\Lock\LockFactoryInterface;
+use Jellyfish\Log\LogServiceProvider;
 use Jellyfish\Process\ProcessFactoryInterface;
+use Jellyfish\Queue\DestinationFactoryInterface;
 use Jellyfish\Queue\MessageFactoryInterface;
 use Jellyfish\Queue\QueueClientInterface;
+use Jellyfish\Queue\QueueServiceProvider;
 use Jellyfish\Serializer\SerializerInterface;
 use Pimple\Container;
 use Psr\Log\LoggerInterface;
@@ -45,46 +48,52 @@ class EventServiceProviderTest extends Unit
 
         $this->container = new Container();
 
-        $this->container->offsetSet('root_dir', function () {
+        $this->container->offsetSet('root_dir', static function () {
             return DIRECTORY_SEPARATOR;
         });
 
-        $this->container->offsetSet('commands', function () {
+        $this->container->offsetSet('commands', static function () {
             return [];
         });
 
-        $this->container->offsetSet('serializer', function () use ($self) {
+        $this->container->offsetSet('serializer', static function () use ($self) {
             return $self->getMockBuilder(SerializerInterface::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         });
 
-        $this->container->offsetSet('lock_factory', function () use ($self) {
+        $this->container->offsetSet('lock_factory', static function () use ($self) {
             return $self->getMockBuilder(LockFactoryInterface::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         });
 
-        $this->container->offsetSet('logger', function () use ($self) {
+        $this->container->offsetSet(LogServiceProvider::CONTAINER_KEY_LOGGER, static function () use ($self) {
             return $self->getMockBuilder(LoggerInterface::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         });
 
-        $this->container->offsetSet('message_factory', function () use ($self) {
+        $this->container->offsetSet('message_factory', static function () use ($self) {
             return $self->getMockBuilder(MessageFactoryInterface::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         });
 
-        $this->container->offsetSet('process_factory', function () use ($self) {
+        $this->container->offsetSet('process_factory', static function () use ($self) {
             return $self->getMockBuilder(ProcessFactoryInterface::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         });
 
-        $this->container->offsetSet('queue_client', function () use ($self) {
+        $this->container->offsetSet(QueueServiceProvider::CONTAINER_KEY_QUEUE_CLIENT, static function () use ($self) {
             return $self->getMockBuilder(QueueClientInterface::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+        });
+
+        $this->container->offsetSet(QueueServiceProvider::CONTAINER_KEY_DESTINATION_FACTORY, static function () use ($self) {
+            return $self->getMockBuilder(DestinationFactoryInterface::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         });
@@ -99,21 +108,21 @@ class EventServiceProviderTest extends Unit
     {
         $this->eventServiceProvider->register($this->container);
 
-        $this->assertTrue($this->container->offsetExists(EventServiceProvider::CONTAINER_KEY_EVENT_FACTORY));
-        $this->assertInstanceOf(EventFactory::class, $this->container->offsetGet(EventServiceProvider::CONTAINER_KEY_EVENT_FACTORY));
+        self::assertTrue($this->container->offsetExists(EventServiceProvider::CONTAINER_KEY_EVENT_FACTORY));
+        self::assertInstanceOf(EventFactory::class, $this->container->offsetGet(EventServiceProvider::CONTAINER_KEY_EVENT_FACTORY));
 
-        $this->assertTrue($this->container->offsetExists(EventServiceProvider::CONTAINER_KEY_EVENT_DISPATCHER));
-        $this->assertInstanceOf(EventDispatcher::class, $this->container->offsetGet(EventServiceProvider::CONTAINER_KEY_EVENT_DISPATCHER));
+        self::assertTrue($this->container->offsetExists(EventServiceProvider::CONTAINER_KEY_EVENT_DISPATCHER));
+        self::assertInstanceOf(EventDispatcher::class, $this->container->offsetGet(EventServiceProvider::CONTAINER_KEY_EVENT_DISPATCHER));
 
-        $this->assertTrue($this->container->offsetExists(EventServiceProvider::CONTAINER_KEY_DEFAULT_EVENT_ERROR_HANDLERS));
-        $this->assertIsArray($this->container->offsetGet(EventServiceProvider::CONTAINER_KEY_DEFAULT_EVENT_ERROR_HANDLERS));
+        self::assertTrue($this->container->offsetExists(EventServiceProvider::CONTAINER_KEY_DEFAULT_EVENT_ERROR_HANDLERS));
+        self::assertIsArray($this->container->offsetGet(EventServiceProvider::CONTAINER_KEY_DEFAULT_EVENT_ERROR_HANDLERS));
 
-        $this->assertTrue($this->container->offsetExists('commands'));
+        self::assertTrue($this->container->offsetExists('commands'));
 
         $commands = $this->container->offsetGet('commands');
 
-        $this->assertCount(2, $commands);
-        $this->assertInstanceOf(EventQueueConsumeCommand::class, $commands[0]);
-        $this->assertInstanceOf(EventQueueWorkerStartCommand::class, $commands[1]);
+        self::assertCount(2, $commands);
+        self::assertInstanceOf(EventQueueConsumeCommand::class, $commands[0]);
+        self::assertInstanceOf(EventQueueWorkerStartCommand::class, $commands[1]);
     }
 }

--- a/packages/queue-rabbit-mq/codeception.yml
+++ b/packages/queue-rabbit-mq/codeception.yml
@@ -19,5 +19,3 @@ coverage:
   enabled: true
   include:
     - src/*
-  exclude:
-    - src/Jellyfish/QueueRabbitMq/QueueRabbitMqServiceProvider.php

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/AbstractConsumer.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/AbstractConsumer.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Jellyfish\Queue\ConsumerInterface;
+use Jellyfish\Queue\DestinationInterface;
+use Jellyfish\Queue\MessageInterface;
+use Jellyfish\Queue\MessageMapperInterface;
+use PhpAmqpLib\Message\AMQPMessage;
+
+abstract class AbstractConsumer implements ConsumerInterface
+{
+    /**
+     * @var \Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    protected $connection;
+
+    /**
+     * @var \Jellyfish\Queue\MessageMapperInterface
+     */
+    protected $messageMapper;
+
+    /**
+     * @param \Jellyfish\QueueRabbitMq\ConnectionInterface $connection
+     * @param \Jellyfish\Queue\MessageMapperInterface $messageMapper
+     */
+    public function __construct(
+        ConnectionInterface $connection,
+        MessageMapperInterface $messageMapper
+    ) {
+        $this->connection = $connection;
+        $this->messageMapper = $messageMapper;
+    }
+
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     * @return \Jellyfish\Queue\MessageInterface|null
+     */
+    protected function doReceiveMessage(DestinationInterface $destination): ?MessageInterface
+    {
+        $messageAsJson = $this->connection->getChannel()->basic_get($destination->getName(), true);
+
+        if ($messageAsJson === null || !($messageAsJson instanceof AMQPMessage)) {
+            return null;
+        }
+
+        return $this->messageMapper->fromJson($messageAsJson->getBody());
+    }
+}

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/AmqpMessageFactory.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/AmqpMessageFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Jellyfish\QueueRabbitMq;
 
 use PhpAmqpLib\Message\AMQPMessage;

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/AmqpMessageFactoryInterface.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/AmqpMessageFactoryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Jellyfish\QueueRabbitMq;
 
 use PhpAmqpLib\Message\AMQPMessage;

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/Connection.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/Connection.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Exception;
+use Jellyfish\Queue\DestinationInterface;
+use Jellyfish\QueueRabbitMq\Exception\CouldNotBindQueueException;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AbstractConnection;
+
+use function strtolower;
+
+class Connection implements ConnectionInterface
+{
+    /**
+     * @var \PhpAmqpLib\Channel\AMQPChannel
+     */
+    protected $channel;
+
+    /**
+     * @var \PhpAmqpLib\Connection\AbstractConnection
+     */
+    protected $connection;
+
+    /**
+     * @param \PhpAmqpLib\Connection\AbstractConnection $connection
+     */
+    public function __construct(AbstractConnection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @return \PhpAmqpLib\Channel\AMQPChannel
+     */
+    public function getChannel(): AMQPChannel
+    {
+        if ($this->channel !== null) {
+            return $this->channel;
+        }
+
+        $this->channel = $this->connection->channel();
+
+        return $this->channel;
+    }
+
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     *
+     * @return \Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    public function createExchange(DestinationInterface $destination): ConnectionInterface
+    {
+        $this->getChannel()->exchange_declare(
+            $destination->getName(),
+            strtolower($destination->getType()),
+            false,
+            true,
+            false
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     *
+     * @return \Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    public function createQueue(DestinationInterface $destination): ConnectionInterface
+    {
+        $this->getChannel()->queue_declare(
+            $destination->getName(),
+            false,
+            true,
+            false,
+            false
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     *
+     * @return \Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    public function createQueueAndBind(DestinationInterface $destination): ConnectionInterface
+    {
+        $this->createQueue($destination);
+
+        $bind = $destination->getProperty('bind');
+
+        if ($bind === null) {
+            throw new CouldNotBindQueueException('Destination property "bind" is not set.');
+        }
+
+        $this->getChannel()->queue_bind($destination->getName(), $bind);
+
+        return $this;
+    }
+
+    /**
+     * @return \Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    public function close(): ConnectionInterface
+    {
+        if ($this->channel !== null) {
+            $this->channel->close();
+        }
+
+        if ($this->connection->isConnected()) {
+            $this->connection->close();
+        }
+
+        return $this;
+    }
+
+    public function __destruct()
+    {
+        try {
+            $this->close();
+        } catch (Exception $exception) {
+            return;
+        }
+    }
+}

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/ConnectionInterface.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/ConnectionInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Jellyfish\Queue\DestinationInterface;
+use PhpAmqpLib\Channel\AMQPChannel;
+
+interface ConnectionInterface
+{
+    /**
+     * @return \PhpAmqpLib\Channel\AMQPChannel
+     */
+    public function getChannel(): AMQPChannel;
+
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     *
+     * @return \Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    public function createExchange(DestinationInterface $destination): ConnectionInterface;
+
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     *
+     * @return \Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    public function createQueue(DestinationInterface $destination): ConnectionInterface;
+
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     *
+     * @return \Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    public function createQueueAndBind(DestinationInterface $destination): ConnectionInterface;
+}

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/Exception/CouldNotBindQueueException.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/Exception/CouldNotBindQueueException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq\Exception;
+
+use Exception;
+
+class CouldNotBindQueueException extends Exception
+{
+}

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/FanoutConsumer.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/FanoutConsumer.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Jellyfish\Queue\DestinationInterface;
+use Jellyfish\Queue\MessageInterface;
+
+class FanoutConsumer extends AbstractConsumer
+{
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     *
+     * @return \Jellyfish\Queue\MessageInterface|null
+     */
+    public function receiveMessage(DestinationInterface $destination): ?MessageInterface
+    {
+        $this->connection->createQueueAndBind($destination);
+
+        return $this->doReceiveMessage($destination);
+    }
+
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     * @param int $limit
+     *
+     * @return \Jellyfish\Queue\MessageInterface[]
+     */
+    public function receiveMessages(DestinationInterface $destination, int $limit): array
+    {
+        $receivedMessages = [];
+        $this->connection->createQueueAndBind($destination);
+
+        for ($i = 0; $i < $limit; $i++) {
+            $receivedMessage = $this->doReceiveMessage($destination);
+
+            if ($receivedMessage === null) {
+                return $receivedMessages;
+            }
+
+            $receivedMessages[] = $receivedMessage;
+        }
+
+        return $receivedMessages;
+    }
+}

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/FanoutProducer.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/FanoutProducer.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Jellyfish\Queue\DestinationInterface;
+use Jellyfish\Queue\MessageInterface;
+use Jellyfish\Queue\MessageMapperInterface;
+use Jellyfish\Queue\ProducerInterface;
+
+class FanoutProducer implements ProducerInterface
+{
+    /**
+     * @var \Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    protected $connection;
+
+    /**
+     * @var \Jellyfish\Queue\MessageMapperInterface
+     */
+    protected $messageMapper;
+
+    /**
+     * @var \Jellyfish\QueueRabbitMq\AmqpMessageFactoryInterface
+     */
+    protected $amqpMessageFactory;
+
+    /**
+     * @param \Jellyfish\QueueRabbitMq\ConnectionInterface $connection
+     * @param \Jellyfish\Queue\MessageMapperInterface $messageMapper
+     * @param \Jellyfish\QueueRabbitMq\AmqpMessageFactoryInterface $amqpMessageFactory
+     */
+    public function __construct(
+        ConnectionInterface $connection,
+        MessageMapperInterface $messageMapper,
+        AmqpMessageFactoryInterface $amqpMessageFactory
+    ) {
+        $this->connection = $connection;
+        $this->messageMapper = $messageMapper;
+        $this->amqpMessageFactory = $amqpMessageFactory;
+    }
+
+
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     * @param \Jellyfish\Queue\MessageInterface $message
+     *
+     * @return \Jellyfish\Queue\ProducerInterface
+     */
+    public function sendMessage(DestinationInterface $destination, MessageInterface $message): ProducerInterface
+    {
+        $json = $this->messageMapper->toJson($message);
+        $amqpMessage = $this->amqpMessageFactory->create($json);
+
+        $this->connection->createExchange($destination);
+        $this->connection->getChannel()->basic_publish($amqpMessage, $destination->getName());
+
+        return $this;
+    }
+}

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/QueueConsumer.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/QueueConsumer.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Jellyfish\Queue\DestinationInterface;
+use Jellyfish\Queue\MessageInterface;
+
+class QueueConsumer extends AbstractConsumer
+{
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     *
+     * @return \Jellyfish\Queue\MessageInterface|null
+     */
+    public function receiveMessage(DestinationInterface $destination): ?MessageInterface
+    {
+        $this->connection->createQueue($destination);
+
+        return $this->doReceiveMessage($destination);
+    }
+
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     * @param int $limit
+     *
+     * @return \Jellyfish\Queue\MessageInterface[]
+     */
+    public function receiveMessages(DestinationInterface $destination, int $limit): array
+    {
+        $receivedMessages = [];
+        $this->connection->createQueue($destination);
+
+        for ($i = 0; $i < $limit; $i++) {
+            $receivedMessage = $this->doReceiveMessage($destination);
+
+            if ($receivedMessage === null) {
+                return $receivedMessages;
+            }
+
+            $receivedMessages[] = $receivedMessage;
+        }
+
+        return $receivedMessages;
+    }
+}

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/QueueProducer.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/QueueProducer.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Jellyfish\Queue\DestinationInterface;
+use Jellyfish\Queue\MessageInterface;
+use Jellyfish\Queue\MessageMapperInterface;
+use Jellyfish\Queue\ProducerInterface;
+
+class QueueProducer implements ProducerInterface
+{
+    /**
+     * @var \Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    protected $connection;
+
+    /**
+     * @var \Jellyfish\Queue\MessageMapperInterface
+     */
+    protected $messageMapper;
+
+    /**
+     * @var \Jellyfish\QueueRabbitMq\AmqpMessageFactoryInterface
+     */
+    protected $amqpMessageFactory;
+
+    /**
+     * @param \Jellyfish\QueueRabbitMq\ConnectionInterface $connection
+     * @param \Jellyfish\Queue\MessageMapperInterface $messageMapper
+     * @param \Jellyfish\QueueRabbitMq\AmqpMessageFactoryInterface $amqpMessageFactory
+     */
+    public function __construct(
+        ConnectionInterface $connection,
+        MessageMapperInterface $messageMapper,
+        AmqpMessageFactoryInterface $amqpMessageFactory
+    ) {
+        $this->connection = $connection;
+        $this->messageMapper = $messageMapper;
+        $this->amqpMessageFactory = $amqpMessageFactory;
+    }
+
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     * @param \Jellyfish\Queue\MessageInterface $message
+     *
+     * @return \Jellyfish\Queue\ProducerInterface
+     */
+    public function sendMessage(DestinationInterface $destination, MessageInterface $message): ProducerInterface
+    {
+        $json = $this->messageMapper->toJson($message);
+        $amqpMessage = $this->amqpMessageFactory->create($json);
+
+        $this->connection->createQueue($destination);
+        $this->connection->getChannel()->basic_publish($amqpMessage, '', $destination->getName());
+
+        return $this;
+    }
+}

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/QueueRabbitMqServiceProvider.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/QueueRabbitMqServiceProvider.php
@@ -4,21 +4,64 @@ declare(strict_types=1);
 
 namespace Jellyfish\QueueRabbitMq;
 
-use PhpAmqpLib\Connection\AbstractConnection;
+use Jellyfish\Queue\DestinationInterface;
+use Jellyfish\Queue\QueueServiceProvider;
 use PhpAmqpLib\Connection\AMQPLazyConnection;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class QueueRabbitMqServiceProvider implements ServiceProviderInterface
 {
+    public const CONTAINER_KEY_CONNECTION = 'queue_rabbit_mq_connection';
+    public const CONTAINER_KEY_AMQP_MESSAGE_FACTORY = 'queue_rabbit_mq_amqp_message_factory';
+
     /**
-     * @param \Pimple\Container $pimple
+     * @param \Pimple\Container $container
      *
      * @return void
      */
-    public function register(Container $pimple): void
+    public function register(Container $container): void
     {
-        $this->registerQueueClient($pimple);
+        $this->registerConnection($container)
+            ->registerAmqpMessageFactory($container)
+            ->registerQueueClient($container);
+    }
+    /**
+     * @param \Pimple\Container $container
+     *
+     * @return \Jellyfish\QueueRabbitMq\QueueRabbitMqServiceProvider
+     */
+    protected function registerConnection(Container $container): QueueRabbitMqServiceProvider
+    {
+        $self = $this;
+
+        $container->offsetSet(
+            static::CONTAINER_KEY_CONNECTION,
+            static function (Container $container) use ($self) {
+                $lazyConnection = $self->createAmqpLazyConnection($container);
+
+                return new Connection($lazyConnection);
+            }
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param \Pimple\Container $container
+     *
+     * @return \Jellyfish\QueueRabbitMq\QueueRabbitMqServiceProvider
+     */
+    protected function registerAmqpMessageFactory(Container $container): QueueRabbitMqServiceProvider
+    {
+        $container->offsetSet(static::CONTAINER_KEY_AMQP_MESSAGE_FACTORY, static function () {
+            return new AmqpMessageFactory();
+        });
+
+        return $this;
     }
 
     /**
@@ -30,13 +73,15 @@ class QueueRabbitMqServiceProvider implements ServiceProviderInterface
     {
         $self = $this;
 
-        $container->offsetSet('queue_client', static function (Container $container) use ($self) {
-            return new QueueClient(
-                $self->createConnection($container),
-                $self->createAmqpMessageFactory(),
-                $container->offsetGet('message_mapper')
-            );
-        });
+        $container->offsetSet(
+            QueueServiceProvider::CONTAINER_KEY_QUEUE_CLIENT,
+            static function (Container $container) use ($self) {
+                return new QueueClient(
+                    $self->createConsumers($container),
+                    $self->createProducers($container)
+                );
+            }
+        );
 
         return $this;
     }
@@ -44,9 +89,9 @@ class QueueRabbitMqServiceProvider implements ServiceProviderInterface
     /**
      * @param \Pimple\Container $container
      *
-     * @return \PhpAmqpLib\Connection\AbstractConnection
+     * @return \PhpAmqpLib\Connection\AMQPLazyConnection
      */
-    protected function createConnection(Container $container): AbstractConnection
+    protected function createAmqpLazyConnection(Container $container): AMQPLazyConnection
     {
         $config = $container->offsetGet('config');
 
@@ -85,10 +130,35 @@ class QueueRabbitMqServiceProvider implements ServiceProviderInterface
     }
 
     /**
-     * @return \Jellyfish\QueueRabbitMq\AmqpMessageFactoryInterface
+     * @param \Pimple\Container $container
+     *
+     * @return \Jellyfish\Queue\ConsumerInterface[]
      */
-    protected function createAmqpMessageFactory(): AmqpMessageFactoryInterface
+    protected function createConsumers(Container $container): array
     {
-        return new AmqpMessageFactory();
+        $connection = $container->offsetGet(static::CONTAINER_KEY_CONNECTION);
+        $messageMapper = $container->offsetGet(QueueServiceProvider::CONTAINER_KEY_MESSAGE_MAPPER);
+
+        return [
+            DestinationInterface::TYPE_QUEUE => new QueueConsumer($connection, $messageMapper),
+            DestinationInterface::TYPE_FANOUT => new FanoutConsumer($connection, $messageMapper)
+        ];
+    }
+
+    /**
+     * @param \Pimple\Container $container
+     *
+     * @return \Jellyfish\Queue\ProducerInterface[]
+     */
+    protected function createProducers(Container $container): array
+    {
+        $connection = $container->offsetGet(static::CONTAINER_KEY_CONNECTION);
+        $messageMapper = $container->offsetGet(QueueServiceProvider::CONTAINER_KEY_MESSAGE_MAPPER);
+        $amqpMessageFactory = $container->offsetGet(static::CONTAINER_KEY_AMQP_MESSAGE_FACTORY);
+
+        return [
+            DestinationInterface::TYPE_QUEUE => new QueueProducer($connection, $messageMapper, $amqpMessageFactory),
+            DestinationInterface::TYPE_FANOUT => new FanoutProducer($connection, $messageMapper, $amqpMessageFactory),
+        ];
     }
 }

--- a/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/AmqpMessageFactoryTest.php
+++ b/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/AmqpMessageFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Jellyfish\QueueRabbitMq;
 
 use Codeception\Test\Unit;

--- a/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/ConnectionTest.php
+++ b/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/ConnectionTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Codeception\Test\Unit;
+use Exception;
+use Jellyfish\Queue\DestinationInterface;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AbstractConnection;
+
+use function strtolower;
+
+class ConnectionTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\PhpAmqpLib\Connection\AbstractConnection
+     */
+    protected $amqpConnectionMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\PhpAmqpLib\Channel\AMQPChannel
+     */
+    protected $amqpChannelMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\DestinationInterface
+     */
+    protected $destinationMock;
+
+    /**
+     * @var \Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    protected $connection;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->amqpConnectionMock = $this->getMockBuilder(AbstractConnection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->amqpChannelMock = $this->getMockBuilder(AMQPChannel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->destinationMock = $this->getMockBuilder(DestinationInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->connection = new Connection($this->amqpConnectionMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetChannel(): void
+    {
+        $this->amqpConnectionMock->expects(self::atLeastOnce())
+            ->method('channel')
+            ->willReturn($this->amqpChannelMock);
+
+        self::assertEquals($this->amqpChannelMock, $this->connection->getChannel());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetChannelTwoTimes(): void
+    {
+        $this->amqpConnectionMock->expects(self::once())
+            ->method('channel')
+            ->willReturn($this->amqpChannelMock);
+
+        self::assertEquals($this->amqpChannelMock, $this->connection->getChannel());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateQueue(): void
+    {
+        $destinationName = 'Foo';
+
+        $this->amqpConnectionMock->expects(self::once())
+            ->method('channel')
+            ->willReturn($this->amqpChannelMock);
+
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getName')
+            ->willReturn($destinationName);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('queue_declare')
+            ->with($destinationName, false, true, false, false);
+
+        self::assertEquals($this->connection, $this->connection->createQueue($this->destinationMock));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateQueueAndBind(): void
+    {
+        $destinationName = 'Foo';
+        $destinationPropertyBind = 'Bar';
+
+        $this->amqpConnectionMock->expects(self::once())
+            ->method('channel')
+            ->willReturn($this->amqpChannelMock);
+
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getName')
+            ->willReturn($destinationName);
+
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getProperty')
+            ->with('bind')
+            ->willReturn($destinationPropertyBind);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('queue_declare')
+            ->with($destinationName, false, true, false, false);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('queue_bind')
+            ->with($destinationName, $destinationPropertyBind);
+
+        self::assertEquals($this->connection, $this->connection->createQueueAndBind($this->destinationMock));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateQueueAndBindWithError(): void
+    {
+        $destinationName = 'Foo';
+
+        $this->amqpConnectionMock->expects(self::once())
+            ->method('channel')
+            ->willReturn($this->amqpChannelMock);
+
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getName')
+            ->willReturn($destinationName);
+
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getProperty')
+            ->with('bind')
+            ->willReturn(null);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('queue_declare')
+            ->with($destinationName, false, true, false, false);
+
+        $this->amqpChannelMock->expects(self::never())
+            ->method('queue_bind')
+            ->with($destinationName, self::anything());
+
+        try {
+            $this->connection->createQueueAndBind($this->destinationMock);
+            self::fail();
+        } catch (Exception $exception) {
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateExchange(): void
+    {
+        $destinationName = 'Foo';
+
+        $this->amqpConnectionMock->expects(self::once())
+            ->method('channel')
+            ->willReturn($this->amqpChannelMock);
+
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getName')
+            ->willReturn($destinationName);
+
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getType')
+            ->willReturn(DestinationInterface::TYPE_FANOUT);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('exchange_declare')
+            ->with($destinationName, strtolower(DestinationInterface::TYPE_FANOUT), false, true, false);
+
+        self::assertEquals($this->connection, $this->connection->createExchange($this->destinationMock));
+    }
+
+    /**
+     * @return void
+     */
+    public function testClose(): void
+    {
+        $this->amqpConnectionMock->expects(self::atLeastOnce())
+            ->method('channel')
+            ->willReturn($this->amqpChannelMock);
+
+        self::assertEquals($this->amqpChannelMock, $this->connection->getChannel());
+
+        $this->amqpConnectionMock->expects(self::atLeastOnce())
+            ->method('isConnected')
+            ->willReturn(true);
+
+        $this->amqpConnectionMock->expects(self::atLeastOnce())
+            ->method('close');
+
+        self::assertEquals($this->connection, $this->connection->close());
+    }
+
+    /**
+     * @return void
+     */
+    public function testDestruct(): void
+    {
+        $this->amqpConnectionMock->expects(self::atLeastOnce())
+            ->method('channel')
+            ->willReturn($this->amqpChannelMock);
+
+        self::assertEquals($this->amqpChannelMock, $this->connection->getChannel());
+
+        $this->amqpConnectionMock->expects(self::atLeastOnce())
+            ->method('isConnected')
+            ->willReturn(true);
+
+        $this->amqpConnectionMock->expects(self::atLeastOnce())
+            ->method('close');
+
+        unset($this->connection);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDestructWithError(): void
+    {
+        $this->amqpConnectionMock->expects(self::atLeastOnce())
+            ->method('channel')
+            ->willReturn($this->amqpChannelMock);
+
+        self::assertEquals($this->amqpChannelMock, $this->connection->getChannel());
+
+        $this->amqpConnectionMock->expects(self::atLeastOnce())
+            ->method('isConnected')
+            ->willReturn(true);
+
+        $this->amqpConnectionMock->expects(self::atLeastOnce())
+            ->method('close')
+            ->willThrowException(new Exception('Foo'));
+
+        unset($this->connection);
+    }
+}

--- a/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/FanoutConsumerTest.php
+++ b/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/FanoutConsumerTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Codeception\Test\Unit;
+use Jellyfish\Queue\DestinationInterface;
+use Jellyfish\Queue\MessageInterface;
+use Jellyfish\Queue\MessageMapperInterface;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Message\AMQPMessage;
+
+class FanoutConsumerTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    protected $connectionMock;
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\MessageMapperInterface
+     */
+    protected $messageMapperMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\PhpAmqpLib\Channel\AMQPChannel
+     */
+    protected $amqpChannelMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\MessageInterface
+     */
+    protected $messageMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\PhpAmqpLib\Message\AMQPMessage
+     */
+    protected $amqpMessageMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\DestinationInterface
+     */
+    protected $destinationMock;
+
+    /**
+     * @var string
+     */
+    protected $queueName;
+
+    /**
+     * @var string
+     */
+    protected $json;
+
+    /**
+     * @var \Jellyfish\Queue\ConsumerInterface
+     */
+    protected $fanoutConsumer;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        $this->connectionMock = $this->getMockBuilder(ConnectionInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->messageMapperMock = $this->getMockBuilder(MessageMapperInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->amqpChannelMock = $this->getMockBuilder(AMQPChannel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->messageMock = $this->getMockBuilder(MessageInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->amqpMessageMock = $this->getMockBuilder(AMQPMessage::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->destinationMock = $this->getMockBuilder(DestinationInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->queueName = 'Foo';
+        $this->json = '{...}';
+
+        $this->fanoutConsumer = new FanoutConsumer(
+            $this->connectionMock,
+            $this->messageMapperMock
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testReceiveMessage(): void
+    {
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getName')
+            ->willReturn($this->queueName);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('createQueueAndBind')
+            ->with($this->destinationMock)
+            ->willReturn($this->connectionMock);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('getChannel')
+            ->willReturn($this->amqpChannelMock);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('basic_get')
+            ->with($this->queueName, true)
+            ->willReturn($this->amqpMessageMock);
+
+        $this->amqpMessageMock->expects(self::atLeastOnce())
+            ->method('getBody')
+            ->willReturn($this->json);
+
+        $this->messageMapperMock->expects(self::atLeastOnce())
+            ->method('fromJson')
+            ->with($this->json)
+            ->willReturn($this->messageMock);
+
+        self::assertEquals(
+            $this->messageMock,
+            $this->fanoutConsumer->receiveMessage($this->destinationMock)
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testReceiveMessageFromEmptyQueue(): void
+    {
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getName')
+            ->willReturn($this->queueName);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('createQueueAndBind')
+            ->with($this->destinationMock)
+            ->willReturn($this->connectionMock);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('getChannel')
+            ->willReturn($this->amqpChannelMock);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('basic_get')
+            ->with($this->queueName, true)
+            ->willReturn(null);
+
+        $this->amqpMessageMock->expects(self::never())
+            ->method('getBody');
+
+        $this->messageMapperMock->expects(self::never())
+            ->method('fromJson')
+            ->with(self::anything());
+
+        self::assertEquals(
+            null,
+            $this->fanoutConsumer->receiveMessage($this->destinationMock)
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testReceiveMessages(): void
+    {
+        $messageMocks = [$this->messageMock];
+
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getName')
+            ->willReturn($this->queueName);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('createQueueAndBind')
+            ->with($this->destinationMock)
+            ->willReturn($this->connectionMock);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('getChannel')
+            ->willReturn($this->amqpChannelMock);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('basic_get')
+            ->with($this->queueName, true)
+            ->willReturnOnConsecutiveCalls($this->amqpMessageMock, null);
+
+        $this->amqpMessageMock->expects(self::atLeastOnce())
+            ->method('getBody')
+            ->willReturn($this->json);
+
+        $this->messageMapperMock->expects(self::atLeastOnce())
+            ->method('fromJson')
+            ->with($this->json)
+            ->willReturn($this->messageMock);
+
+        self::assertEquals(
+            $messageMocks,
+            $this->fanoutConsumer->receiveMessages($this->destinationMock, 1)
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testReceiveMessagesBelowCount(): void
+    {
+        $messageMocks = [$this->messageMock];
+
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getName')
+            ->willReturn($this->queueName);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('createQueueAndBind')
+            ->with($this->destinationMock)
+            ->willReturn($this->connectionMock);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('getChannel')
+            ->willReturn($this->amqpChannelMock);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('basic_get')
+            ->with($this->queueName, true)
+            ->willReturnOnConsecutiveCalls($this->amqpMessageMock, null);
+
+        $this->amqpMessageMock->expects(self::once())
+            ->method('getBody')
+            ->willReturn($this->json);
+
+        $this->messageMapperMock->expects(self::once())
+            ->method('fromJson')
+            ->with($this->json)
+            ->willReturn($this->messageMock);
+
+        self::assertEquals(
+            $messageMocks,
+            $this->fanoutConsumer->receiveMessages($this->destinationMock, 2)
+        );
+    }
+}

--- a/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/FanoutProducerTest.php
+++ b/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/FanoutProducerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Codeception\Test\Unit;
+use Jellyfish\Queue\DestinationInterface;
+use Jellyfish\Queue\MessageInterface;
+use Jellyfish\Queue\MessageMapperInterface;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Message\AMQPMessage;
+
+class FanoutProducerTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    protected $connectionMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\MessageMapperInterface
+     */
+    protected $messageMapperMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\PhpAmqpLib\Channel\AMQPChannel
+     */
+    protected $amqpChannelMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\MessageInterface
+     */
+    protected $messageMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\PhpAmqpLib\Message\AMQPMessage
+     */
+    protected $amqpMessageMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\QueueRabbitMq\AmqpMessageFactoryInterface
+     */
+    protected $amqpMessageFactoryMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\DestinationInterface
+     */
+    protected $destinationMock;
+
+    /**
+     * @var string
+     */
+    protected $queueName;
+
+    /**
+     * @var string
+     */
+    protected $json;
+
+    /**
+     * @var \Jellyfish\QueueRabbitMq\FanoutProducer
+     */
+    protected $fanoutProducer;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        $this->connectionMock = $this->getMockBuilder(ConnectionInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->messageMapperMock = $this->getMockBuilder(MessageMapperInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->amqpChannelMock = $this->getMockBuilder(AMQPChannel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->messageMock = $this->getMockBuilder(MessageInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->amqpMessageMock = $this->getMockBuilder(AMQPMessage::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->amqpMessageFactoryMock = $this->getMockBuilder(AmqpMessageFactoryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->destinationMock = $this->getMockBuilder(DestinationInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->queueName = 'Foo';
+        $this->json = '{...}';
+
+        $this->fanoutProducer = new FanoutProducer(
+            $this->connectionMock,
+            $this->messageMapperMock,
+            $this->amqpMessageFactoryMock
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testSendMessage(): void
+    {
+        $this->messageMapperMock->expects(self::atLeastOnce())
+            ->method('toJson')
+            ->with($this->messageMock)
+            ->willReturn($this->json);
+
+        $this->amqpMessageFactoryMock->expects(self::atLeastOnce())
+            ->method('create')
+            ->with($this->json)
+            ->willReturn($this->amqpMessageMock);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('createExchange')
+            ->with($this->destinationMock)
+            ->willReturn($this->connectionMock);
+
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getName')
+            ->willReturn($this->queueName);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('getChannel')
+            ->willReturn($this->amqpChannelMock);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('basic_publish')
+            ->with($this->amqpMessageMock, $this->queueName);
+
+        self::assertEquals(
+            $this->fanoutProducer,
+            $this->fanoutProducer->sendMessage($this->destinationMock, $this->messageMock)
+        );
+    }
+}

--- a/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/QueueConsumerTest.php
+++ b/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/QueueConsumerTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Codeception\Test\Unit;
+use Jellyfish\Queue\DestinationInterface;
+use Jellyfish\Queue\MessageInterface;
+use Jellyfish\Queue\MessageMapperInterface;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Message\AMQPMessage;
+
+class QueueConsumerTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    protected $connectionMock;
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\MessageMapperInterface
+     */
+    protected $messageMapperMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\PhpAmqpLib\Channel\AMQPChannel
+     */
+    protected $amqpChannelMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\MessageInterface
+     */
+    protected $messageMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\PhpAmqpLib\Message\AMQPMessage
+     */
+    protected $amqpMessageMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\DestinationInterface
+     */
+    protected $destinationMock;
+
+    /**
+     * @var string
+     */
+    protected $queueName;
+
+    /**
+     * @var string
+     */
+    protected $json;
+
+    /**
+     * @var \Jellyfish\Queue\ConsumerInterface
+     */
+    protected $queueConsumer;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        $this->connectionMock = $this->getMockBuilder(ConnectionInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->messageMapperMock = $this->getMockBuilder(MessageMapperInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->amqpChannelMock = $this->getMockBuilder(AMQPChannel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->messageMock = $this->getMockBuilder(MessageInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->amqpMessageMock = $this->getMockBuilder(AMQPMessage::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->destinationMock = $this->getMockBuilder(DestinationInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->queueName = 'Foo';
+        $this->json = '{...}';
+
+        $this->queueConsumer = new QueueConsumer(
+            $this->connectionMock,
+            $this->messageMapperMock
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testReceiveMessage(): void
+    {
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getName')
+            ->willReturn($this->queueName);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('createQueue')
+            ->with($this->destinationMock)
+            ->willReturn($this->connectionMock);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('getChannel')
+            ->willReturn($this->amqpChannelMock);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('basic_get')
+            ->with($this->queueName, true)
+            ->willReturn($this->amqpMessageMock);
+
+        $this->amqpMessageMock->expects(self::atLeastOnce())
+            ->method('getBody')
+            ->willReturn($this->json);
+
+        $this->messageMapperMock->expects(self::atLeastOnce())
+            ->method('fromJson')
+            ->with($this->json)
+            ->willReturn($this->messageMock);
+
+        self::assertEquals(
+            $this->messageMock,
+            $this->queueConsumer->receiveMessage($this->destinationMock)
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testReceiveMessageFromEmptyQueue(): void
+    {
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getName')
+            ->willReturn($this->queueName);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('createQueue')
+            ->with($this->destinationMock)
+            ->willReturn($this->connectionMock);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('getChannel')
+            ->willReturn($this->amqpChannelMock);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('basic_get')
+            ->with($this->queueName, true)
+            ->willReturn(null);
+
+        $this->amqpMessageMock->expects(self::never())
+            ->method('getBody');
+
+        $this->messageMapperMock->expects(self::never())
+            ->method('fromJson')
+            ->with(self::anything());
+
+        self::assertEquals(
+            null,
+            $this->queueConsumer->receiveMessage($this->destinationMock)
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testReceiveMessages(): void
+    {
+        $messageMocks = [$this->messageMock];
+
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getName')
+            ->willReturn($this->queueName);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('createQueue')
+            ->with($this->destinationMock)
+            ->willReturn($this->connectionMock);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('getChannel')
+            ->willReturn($this->amqpChannelMock);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('basic_get')
+            ->with($this->queueName, true)
+            ->willReturnOnConsecutiveCalls($this->amqpMessageMock, null);
+
+        $this->amqpMessageMock->expects(self::atLeastOnce())
+            ->method('getBody')
+            ->willReturn($this->json);
+
+        $this->messageMapperMock->expects(self::atLeastOnce())
+            ->method('fromJson')
+            ->with($this->json)
+            ->willReturn($this->messageMock);
+
+        self::assertEquals(
+            $messageMocks,
+            $this->queueConsumer->receiveMessages($this->destinationMock, 1)
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testReceiveMessagesBelowCount(): void
+    {
+        $messageMocks = [$this->messageMock];
+
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getName')
+            ->willReturn($this->queueName);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('createQueue')
+            ->with($this->destinationMock)
+            ->willReturn($this->connectionMock);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('getChannel')
+            ->willReturn($this->amqpChannelMock);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('basic_get')
+            ->with($this->queueName, true)
+            ->willReturnOnConsecutiveCalls($this->amqpMessageMock, null);
+
+        $this->amqpMessageMock->expects(self::once())
+            ->method('getBody')
+            ->willReturn($this->json);
+
+        $this->messageMapperMock->expects(self::once())
+            ->method('fromJson')
+            ->with($this->json)
+            ->willReturn($this->messageMock);
+
+        self::assertEquals(
+            $messageMocks,
+            $this->queueConsumer->receiveMessages($this->destinationMock, 2)
+        );
+    }
+}

--- a/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/QueueProducerTest.php
+++ b/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/QueueProducerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Codeception\Test\Unit;
+use Jellyfish\Queue\DestinationInterface;
+use Jellyfish\Queue\MessageInterface;
+use Jellyfish\Queue\MessageMapperInterface;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Message\AMQPMessage;
+
+class QueueProducerTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\QueueRabbitMq\ConnectionInterface
+     */
+    protected $connectionMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\MessageMapperInterface
+     */
+    protected $messageMapperMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\PhpAmqpLib\Channel\AMQPChannel
+     */
+    protected $amqpChannelMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\MessageInterface
+     */
+    protected $messageMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\PhpAmqpLib\Message\AMQPMessage
+     */
+    protected $amqpMessageMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\QueueRabbitMq\AmqpMessageFactoryInterface
+     */
+    protected $amqpMessageFactoryMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\DestinationInterface
+     */
+    protected $destinationMock;
+
+    /**
+     * @var string
+     */
+    protected $queueName;
+
+    /**
+     * @var string
+     */
+    protected $json;
+
+    /**
+     * @var \Jellyfish\Queue\ProducerInterface
+     */
+    protected $queueProducer;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        $this->connectionMock = $this->getMockBuilder(ConnectionInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->messageMapperMock = $this->getMockBuilder(MessageMapperInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->amqpChannelMock = $this->getMockBuilder(AMQPChannel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->messageMock = $this->getMockBuilder(MessageInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->amqpMessageMock = $this->getMockBuilder(AMQPMessage::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->amqpMessageFactoryMock = $this->getMockBuilder(AmqpMessageFactoryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->destinationMock = $this->getMockBuilder(DestinationInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->queueName = 'Foo';
+        $this->json = '{...}';
+
+        $this->queueProducer = new QueueProducer(
+            $this->connectionMock,
+            $this->messageMapperMock,
+            $this->amqpMessageFactoryMock
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testSendMessage(): void
+    {
+        $this->messageMapperMock->expects(self::atLeastOnce())
+            ->method('toJson')
+            ->with($this->messageMock)
+            ->willReturn($this->json);
+
+        $this->amqpMessageFactoryMock->expects(self::atLeastOnce())
+            ->method('create')
+            ->with($this->json)
+            ->willReturn($this->amqpMessageMock);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('createQueue')
+            ->with($this->destinationMock)
+            ->willReturn($this->connectionMock);
+
+        $this->destinationMock->expects(self::atLeastOnce())
+            ->method('getName')
+            ->willReturn($this->queueName);
+
+        $this->connectionMock->expects(self::atLeastOnce())
+            ->method('getChannel')
+            ->willReturn($this->amqpChannelMock);
+
+        $this->amqpChannelMock->expects(self::atLeastOnce())
+            ->method('basic_publish')
+            ->with($this->amqpMessageMock, '', $this->queueName);
+
+        self::assertEquals(
+            $this->queueProducer,
+            $this->queueProducer->sendMessage($this->destinationMock, $this->messageMock)
+        );
+    }
+}

--- a/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/QueueRabbitMqServiceProviderTest.php
+++ b/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/QueueRabbitMqServiceProviderTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Codeception\Test\Unit;
+use Jellyfish\Config\ConfigInterface;
+use Jellyfish\Config\ConfigServiceProvider;
+use Jellyfish\Queue\MessageMapperInterface;
+use Jellyfish\Queue\QueueServiceProvider;
+use Jellyfish\Serializer\SerializerInterface;
+use Pimple\Container;
+
+class QueueRabbitMqServiceProviderTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Config\ConfigInterface
+     */
+    protected $configMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\MessageMapperInterface
+     */
+    protected $messageMapperMock;
+
+    /**
+     * @var \Pimple\Container
+     */
+    protected $container;
+
+    /**
+     * @var \Jellyfish\QueueRabbitMq\QueueRabbitMqServiceProvider
+     */
+    protected $queueRabbitMqServiceProvider;
+
+    /**
+     * @return void
+     *
+     * @throws \Exception
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $self = $this;
+
+        $this->container = new Container();
+
+        $this->configMock = $this->getMockBuilder(ConfigInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->messageMapperMock = $this->getMockBuilder(MessageMapperInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->container->offsetSet(ConfigServiceProvider::CONTAINER_KEY_CONFIG, static function () use ($self) {
+            return $self->configMock;
+        });
+
+        $this->container->offsetSet(QueueServiceProvider::CONTAINER_KEY_MESSAGE_MAPPER, static function () use ($self) {
+            return $self->messageMapperMock;
+        });
+
+        $this->queueRabbitMqServiceProvider = new QueueRabbitMqServiceProvider();
+    }
+
+    /**
+     * @return void
+     */
+    public function testRegister(): void
+    {
+        $this->configMock->expects(self::atLeastOnce())
+            ->method('get')
+            ->withConsecutive(
+                [QueueRabbitMqConstants::RABBIT_MQ_HOST, QueueRabbitMqConstants::DEFAULT_RABBIT_MQ_HOST],
+                [QueueRabbitMqConstants::RABBIT_MQ_PORT, QueueRabbitMqConstants::DEFAULT_RABBIT_MQ_PORT],
+                [QueueRabbitMqConstants::RABBIT_MQ_USER, QueueRabbitMqConstants::DEFAULT_RABBIT_MQ_USER],
+                [QueueRabbitMqConstants::RABBIT_MQ_PASSWORD, QueueRabbitMqConstants::DEFAULT_RABBIT_MQ_PASSWORD],
+                [QueueRabbitMqConstants::RABBIT_MQ_VHOST, QueueRabbitMqConstants::DEFAULT_RABBIT_MQ_VHOST]
+            )->willReturnOnConsecutiveCalls(
+                QueueRabbitMqConstants::DEFAULT_RABBIT_MQ_HOST,
+                QueueRabbitMqConstants::DEFAULT_RABBIT_MQ_PORT,
+                QueueRabbitMqConstants::DEFAULT_RABBIT_MQ_USER,
+                QueueRabbitMqConstants::DEFAULT_RABBIT_MQ_PASSWORD,
+                QueueRabbitMqConstants::DEFAULT_RABBIT_MQ_VHOST
+            );
+
+        $this->queueRabbitMqServiceProvider->register($this->container);
+
+        self::assertTrue($this->container->offsetExists(QueueRabbitMqServiceProvider::CONTAINER_KEY_CONNECTION));
+        self::assertInstanceOf(
+            ConnectionInterface::class,
+            $this->container->offsetGet(QueueRabbitMqServiceProvider::CONTAINER_KEY_CONNECTION)
+        );
+
+        self::assertTrue($this->container->offsetExists(QueueRabbitMqServiceProvider::CONTAINER_KEY_AMQP_MESSAGE_FACTORY));
+        self::assertInstanceOf(
+            AmqpMessageFactory::class,
+            $this->container->offsetGet(QueueRabbitMqServiceProvider::CONTAINER_KEY_AMQP_MESSAGE_FACTORY)
+        );
+
+        self::assertTrue($this->container->offsetExists(QueueServiceProvider::CONTAINER_KEY_QUEUE_CLIENT));
+        self::assertInstanceOf(
+            QueueClient::class,
+            $this->container->offsetGet(QueueServiceProvider::CONTAINER_KEY_QUEUE_CLIENT)
+        );
+    }
+}

--- a/packages/queue/src/Jellyfish/Queue/ConsumerInterface.php
+++ b/packages/queue/src/Jellyfish/Queue/ConsumerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Jellyfish\Queue;
+
+interface ConsumerInterface
+{
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     *
+     * @return \Jellyfish\Queue\MessageInterface|null
+     */
+    public function receiveMessage(DestinationInterface $destination): ?MessageInterface;
+
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     * @param int $limit
+     *
+     * @return \Jellyfish\Queue\MessageInterface[]
+     */
+    public function receiveMessages(DestinationInterface $destination, int $limit): array;
+}

--- a/packages/queue/src/Jellyfish/Queue/Destination.php
+++ b/packages/queue/src/Jellyfish/Queue/Destination.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\Queue;
+
+class Destination implements DestinationInterface
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var string[]
+     */
+    protected $properties;
+
+    public function __construct()
+    {
+        $this->properties = [];
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return \Jellyfish\Queue\DestinationInterface
+     */
+    public function setName(string $name): DestinationInterface
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return \Jellyfish\Queue\DestinationInterface
+     */
+    public function setType(string $type): DestinationInterface
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return string|null
+     */
+    public function getProperty(string $name): ?string
+    {
+        if (!isset($this->properties[$name])) {
+            return null;
+        }
+
+        return $this->properties[$name];
+    }
+
+    /**
+     * @param string $name
+     * @param string $value
+     *
+     * @return \Jellyfish\Queue\DestinationInterface
+     */
+    public function setProperty(string $name, string $value): DestinationInterface
+    {
+        $this->properties[$name] = $value;
+
+        return $this;
+    }
+}

--- a/packages/queue/src/Jellyfish/Queue/DestinationFactory.php
+++ b/packages/queue/src/Jellyfish/Queue/DestinationFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jellyfish\Queue;
+
+class DestinationFactory implements DestinationFactoryInterface
+{
+    /**
+     * @return \Jellyfish\Queue\DestinationInterface
+     */
+    public function create(): DestinationInterface
+    {
+        return new Destination();
+    }
+}

--- a/packages/queue/src/Jellyfish/Queue/DestinationFactoryInterface.php
+++ b/packages/queue/src/Jellyfish/Queue/DestinationFactoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\Queue;
+
+interface DestinationFactoryInterface
+{
+    /**
+     * @return \Jellyfish\Queue\DestinationInterface
+     */
+    public function create(): DestinationInterface;
+}

--- a/packages/queue/src/Jellyfish/Queue/DestinationInterface.php
+++ b/packages/queue/src/Jellyfish/Queue/DestinationInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\Queue;
+
+interface DestinationInterface
+{
+    public const TYPE_QUEUE = 'QUEUE';
+    public const TYPE_FANOUT = 'FANOUT';
+
+    /**
+     * @return string
+     */
+    public function getName(): string;
+
+    /**
+     * @param string $name
+     *
+     * @return \Jellyfish\Queue\DestinationInterface
+     */
+    public function setName(string $name): DestinationInterface;
+
+    /**
+     * @return string
+     */
+    public function getType(): string;
+
+    /**
+     * @param string $type
+     *
+     * @return \Jellyfish\Queue\DestinationInterface
+     */
+    public function setType(string $type): DestinationInterface;
+
+    /**
+     * @param string $name
+     *
+     * @return string|null
+     */
+    public function getProperty(string $name): ?string;
+
+    /**
+     * @param string $name
+     * @param string $value
+     *
+     * @return \Jellyfish\Queue\DestinationInterface
+     */
+    public function setProperty(string $name, string $value): DestinationInterface;
+}

--- a/packages/queue/src/Jellyfish/Queue/Exception/ConsumerNotFoundException.php
+++ b/packages/queue/src/Jellyfish/Queue/Exception/ConsumerNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jellyfish\Queue\Exception;
+
+use Exception;
+
+class ConsumerNotFoundException extends Exception
+{
+}

--- a/packages/queue/src/Jellyfish/Queue/Exception/ProducerNotFoundException.php
+++ b/packages/queue/src/Jellyfish/Queue/Exception/ProducerNotFoundException.php
@@ -2,6 +2,8 @@
 
 namespace Jellyfish\Queue\Exception;
 
-class ProducerNotFoundException extends \Exception
+use Exception;
+
+class ProducerNotFoundException extends Exception
 {
 }

--- a/packages/queue/src/Jellyfish/Queue/Exception/ProducerNotFoundException.php
+++ b/packages/queue/src/Jellyfish/Queue/Exception/ProducerNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jellyfish\Queue\Exception;
+
+class ProducerNotFoundException extends \Exception
+{
+}

--- a/packages/queue/src/Jellyfish/Queue/ProducerInterface.php
+++ b/packages/queue/src/Jellyfish/Queue/ProducerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jellyfish\Queue;
+
+interface ProducerInterface
+{
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     * @param \Jellyfish\Queue\MessageInterface $message
+     *
+     * @return \Jellyfish\Queue\ProducerInterface
+     */
+    public function sendMessage(DestinationInterface $destination, MessageInterface $message): ProducerInterface;
+}

--- a/packages/queue/src/Jellyfish/Queue/QueueClientInterface.php
+++ b/packages/queue/src/Jellyfish/Queue/QueueClientInterface.php
@@ -7,25 +7,41 @@ namespace Jellyfish\Queue;
 interface QueueClientInterface
 {
     /**
-     * @param string $queueName
+     * @param string $type
+     * @param \Jellyfish\Queue\ConsumerInterface $consumer
+     *
+     * @return \Jellyfish\Queue\QueueClientInterface
+     */
+    public function setConsumer(string $type, ConsumerInterface $consumer): QueueClientInterface;
+
+    /**
+     * @param string $type
+     * @param \Jellyfish\Queue\ProducerInterface $producer
+     *
+     * @return \Jellyfish\Queue\QueueClientInterface
+     */
+    public function setProducer(string $type, ProducerInterface $producer): QueueClientInterface;
+
+    /**
+     * @param \Jellyfish\Queue\DestinationInterface $destination
      *
      * @return \Jellyfish\Queue\MessageInterface|null
      */
-    public function receiveMessage(string $queueName): ?MessageInterface;
+    public function receiveMessage(DestinationInterface $destination): ?MessageInterface;
 
     /**
-     * @param string $queueName
-     * @param int $count
+     * @param \Jellyfish\Queue\DestinationInterface $destination
+     * @param int $limit
      *
      * @return \Jellyfish\Queue\MessageInterface[]
      */
-    public function receiveMessages(string $queueName, int $count): array;
+    public function receiveMessages(DestinationInterface $destination, int $limit): array;
 
     /**
-     * @param string $queueName
+     * @param \Jellyfish\Queue\DestinationInterface $destination
      * @param \Jellyfish\Queue\MessageInterface $message
      *
      * @return \Jellyfish\Queue\QueueClientInterface
      */
-    public function sendMessage(string $queueName, MessageInterface $message): QueueClientInterface;
+    public function sendMessage(DestinationInterface $destination, MessageInterface $message): QueueClientInterface;
 }

--- a/packages/queue/src/Jellyfish/Queue/QueueServiceProvider.php
+++ b/packages/queue/src/Jellyfish/Queue/QueueServiceProvider.php
@@ -9,15 +9,21 @@ use Pimple\ServiceProviderInterface;
 
 class QueueServiceProvider implements ServiceProviderInterface
 {
+    public const CONTAINER_KEY_MESSAGE_FACTORY = 'message_factory';
+    public const CONTAINER_KEY_MESSAGE_MAPPER = 'message_mapper';
+    public const CONTAINER_KEY_DESTINATION_FACTORY = 'destination_factory';
+    public const CONTAINER_KEY_QUEUE_CLIENT = 'queue_client';
+
     /**
-     * @param Container $pimple A container instance
+     * @param Container $container
      *
      * @return void
      */
-    public function register(Container $pimple): void
+    public function register(Container $container): void
     {
-        $this->registerMessageFactory($pimple)
-            ->registerMessageMapper($pimple);
+        $this->registerMessageFactory($container)
+            ->registerMessageMapper($container)
+            ->registerDestinationFactory($container);
     }
 
     /**
@@ -27,7 +33,7 @@ class QueueServiceProvider implements ServiceProviderInterface
      */
     protected function registerMessageFactory(Container $container): QueueServiceProvider
     {
-        $container->offsetSet('message_factory', function () {
+        $container->offsetSet(static::CONTAINER_KEY_MESSAGE_FACTORY, static function () {
             return new MessageFactory();
         });
 
@@ -41,10 +47,19 @@ class QueueServiceProvider implements ServiceProviderInterface
      */
     protected function registerMessageMapper(Container $container): QueueServiceProvider
     {
-        $container->offsetSet('message_mapper', function (Container $container) {
+        $container->offsetSet(static::CONTAINER_KEY_MESSAGE_MAPPER, static function (Container $container) {
             return new MessageMapper(
                 $container->offsetGet('serializer')
             );
+        });
+
+        return $this;
+    }
+
+    protected function registerDestinationFactory(Container $container): QueueServiceProvider
+    {
+        $container->offsetSet(static::CONTAINER_KEY_DESTINATION_FACTORY, static function () {
+            return new DestinationFactory();
         });
 
         return $this;

--- a/packages/queue/tests/Jellyfish/Queue/DestinationFactoryTest.php
+++ b/packages/queue/tests/Jellyfish/Queue/DestinationFactoryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Jellyfish\Queue;
+
+use Codeception\Test\Unit;
+
+class DestinationFactoryTest extends Unit
+{
+    /**
+     * @var \Jellyfish\Queue\DestinationFactory
+     */
+    protected $destinationFactory;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->destinationFactory = new DestinationFactory();
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreate(): void
+    {
+        $destination = $this->destinationFactory->create(DestinationInterface::TYPE_FANOUT);
+
+        self::assertInstanceOf(Destination::class, $destination);
+    }
+}

--- a/packages/queue/tests/Jellyfish/Queue/DestinationTest.php
+++ b/packages/queue/tests/Jellyfish/Queue/DestinationTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jellyfish\Queue;
+
+use Codeception\Test\Unit;
+
+class DestinationTest extends Unit
+{
+    /**
+     * @var \Jellyfish\Queue\DestinationInterface
+     */
+    protected $destination;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->destination = new Destination();
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetAndGetName(): void
+    {
+        $name = 'Foo';
+
+        $this->destination->setName($name);
+        self::assertEquals($name, $this->destination->getName());
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetAndGetType(): void
+    {
+        $this->destination->setType(DestinationInterface::TYPE_FANOUT);
+        self::assertEquals(DestinationInterface::TYPE_FANOUT, $this->destination->getType());
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetAndGetProperty(): void
+    {
+        $propertyName = 'bind';
+        $propertyValue = 'QueueX';
+
+        $this->destination->setProperty($propertyName, $propertyValue);
+        self::assertEquals($propertyValue, $this->destination->getProperty($propertyName));
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetNonExistingHeader(): void
+    {
+        $propertyName = 'bind';
+
+        self::assertEquals(null, $this->destination->getProperty($propertyName));
+    }
+}

--- a/packages/queue/tests/Jellyfish/Queue/QueueServiceProviderTest.php
+++ b/packages/queue/tests/Jellyfish/Queue/QueueServiceProviderTest.php
@@ -38,7 +38,7 @@ class QueueServiceProviderTest extends Unit
 
         $this->container = new Container();
 
-        $this->container->offsetSet('serializer', function () use ($self) {
+        $this->container->offsetSet('serializer', static function () use ($self) {
             return $self->getMockBuilder(SerializerInterface::class)
                 ->disableOriginalConstructor()
                 ->getMock();
@@ -54,10 +54,13 @@ class QueueServiceProviderTest extends Unit
     {
         $this->queueServiceProvider->register($this->container);
 
-        $messageMapper = $this->container->offsetGet('message_mapper');
-        $this->assertInstanceOf(MessageMapper::class, $messageMapper);
+        $messageMapper = $this->container->offsetGet(QueueServiceProvider::CONTAINER_KEY_MESSAGE_MAPPER);
+        self::assertInstanceOf(MessageMapper::class, $messageMapper);
 
-        $messageFactory = $this->container->offsetGet('message_factory');
-        $this->assertInstanceOf(MessageFactory::class, $messageFactory);
+        $messageFactory = $this->container->offsetGet(QueueServiceProvider::CONTAINER_KEY_MESSAGE_FACTORY);
+        self::assertInstanceOf(MessageFactory::class, $messageFactory);
+
+        $destinationFactory = $this->container->offsetGet(QueueServiceProvider::CONTAINER_KEY_DESTINATION_FACTORY);
+        self::assertInstanceOf(DestinationFactory::class, $destinationFactory);
     }
 }


### PR DESCRIPTION
- allow to use exchange type fanout (broadcasting) -> https://www.rabbitmq.com/tutorials/tutorial-three-php.html
- add own consumer and producer for destination types
- add constants for container keys
- include QueueRabbitMqServiceProvider in testing
- ...