### PR TITLE
Create exchange with correct name 🪲

### DIFF
--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/Connection.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/Connection.php
@@ -6,7 +6,7 @@ namespace Jellyfish\QueueRabbitMq;
 
 use Exception;
 use Jellyfish\Queue\DestinationInterface;
-use Jellyfish\QueueRabbitMq\Exception\CouldNotBindQueueException;
+use Jellyfish\QueueRabbitMq\Exception\MissingDestinationPropertyException;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AbstractConnection;
 
@@ -94,7 +94,7 @@ class Connection implements ConnectionInterface
         $bind = $destination->getProperty('bind');
 
         if ($bind === null) {
-            throw new CouldNotBindQueueException('Destination property "bind" is not set.');
+            throw new MissingDestinationPropertyException('Destination property "bind" is not set.');
         }
 
         $this->getChannel()->queue_bind($destination->getName(), $bind);

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/Destination.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/Destination.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Jellyfish\Queue;
+namespace Jellyfish\QueueRabbitMq;
+
+use Jellyfish\Queue\DestinationInterface;
 
 class Destination implements DestinationInterface
 {

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/DestinationFactory.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/DestinationFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Jellyfish\Queue\DestinationInterface;
+
+class DestinationFactory implements DestinationFactoryInterface
+{
+    /**
+     * @return \Jellyfish\Queue\DestinationInterface
+     */
+    public function create(): DestinationInterface
+    {
+        return new Destination();
+    }
+}

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/DestinationFactoryInterface.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/DestinationFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Jellyfish\Queue\DestinationInterface;
+
+interface DestinationFactoryInterface
+{
+    /**
+     * @return \Jellyfish\Queue\DestinationInterface
+     */
+    public function create(): DestinationInterface;
+}

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/Exception/MissingDestinationPropertyException.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/Exception/MissingDestinationPropertyException.php
@@ -6,6 +6,6 @@ namespace Jellyfish\QueueRabbitMq\Exception;
 
 use Exception;
 
-class CouldNotBindQueueException extends Exception
+class MissingDestinationPropertyException extends Exception
 {
 }

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/Message.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/Message.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Jellyfish\Queue;
+namespace Jellyfish\QueueRabbitMq;
+
+use Jellyfish\Queue\MessageInterface;
 
 use function array_key_exists;
 

--- a/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/MessageMapper.php
+++ b/packages/queue-rabbit-mq/src/Jellyfish/QueueRabbitMq/MessageMapper.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Jellyfish\QueueRabbitMq;
 
-use Jellyfish\Queue\Message;
 use Jellyfish\Queue\MessageInterface;
 use Jellyfish\Serializer\SerializerFacadeInterface;
 

--- a/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/DestinationFactoryTest.php
+++ b/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/DestinationFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jellyfish\QueueRabbitMq;
+
+use Codeception\Test\Unit;
+
+class DestinationFactoryTest extends Unit
+{
+    /**
+     * @var \Jellyfish\QueueRabbitMq\DestinationFactory
+     */
+    protected $destinationFactory;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->destinationFactory = new DestinationFactory();
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreate(): void
+    {
+        static::assertInstanceOf(
+            Destination::class,
+            $this->destinationFactory->create()
+        );
+    }
+}

--- a/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/DestinationTest.php
+++ b/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/DestinationTest.php
@@ -2,9 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Jellyfish\Queue;
+namespace Jellyfish\QueueRabbitMq;
 
 use Codeception\Test\Unit;
+use Jellyfish\Queue\DestinationInterface;
 
 class DestinationTest extends Unit
 {

--- a/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/FanoutConsumerTest.php
+++ b/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/FanoutConsumerTest.php
@@ -226,7 +226,8 @@ class FanoutConsumerTest extends Unit
         try {
             $this->fanoutConsumer->receiveMessage($this->destinationMock);
             static::fail();
-        } catch (Exception $exception) {}
+        } catch (Exception $exception) {
+        }
     }
 
     /**

--- a/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/FanoutConsumerTest.php
+++ b/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/FanoutConsumerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Jellyfish\QueueRabbitMq;
 
 use Codeception\Test\Unit;
+use Exception;
 use Jellyfish\Queue\DestinationInterface;
 use Jellyfish\Queue\MessageInterface;
 use PhpAmqpLib\Channel\AMQPChannel;
@@ -37,6 +38,16 @@ class FanoutConsumerTest extends Unit
     protected $amqpMessageMock;
 
     /**
+     * @var \Jellyfish\QueueRabbitMq\DestinationFactoryInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $destinationFactoryMock;
+
+    /**
+     * @var \Jellyfish\Queue\DestinationInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $exchangeDestinationMock;
+
+    /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\Jellyfish\Queue\DestinationInterface
      */
     protected $destinationMock;
@@ -45,6 +56,11 @@ class FanoutConsumerTest extends Unit
      * @var string
      */
     protected $queueName;
+
+    /**
+     * @var string
+     */
+    protected $bind;
 
     /**
      * @var string
@@ -86,17 +102,27 @@ class FanoutConsumerTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->destinationFactoryMock = $this->getMockBuilder(DestinationFactoryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->exchangeDestinationMock = $this->getMockBuilder(DestinationInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->destinationMock = $this->getMockBuilder(DestinationInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $this->queueName = 'Foo';
+        $this->bind = 'FooBar';
         $this->propertyName = 'Bar';
         $this->json = '{...}';
 
         $this->fanoutConsumer = new FanoutConsumer(
             $this->connectionMock,
-            $this->messageMapperMock
+            $this->messageMapperMock,
+            $this->destinationFactoryMock
         );
     }
 
@@ -105,14 +131,42 @@ class FanoutConsumerTest extends Unit
      */
     public function testReceiveMessage(): void
     {
+        $this->destinationFactoryMock->expects(static::atLeastOnce())
+            ->method('create')
+            ->willReturn($this->exchangeDestinationMock);
+
         $this->destinationMock->expects(static::atLeastOnce())
-            ->method('getName')
-            ->willReturn($this->queueName);
+            ->method('getProperty')
+            ->with('bind')
+            ->willReturn($this->bind);
+
+        $this->exchangeDestinationMock->expects(static::atLeastOnce())
+            ->method('setName')
+            ->with($this->bind)
+            ->willReturn($this->exchangeDestinationMock);
+
+        $this->destinationMock->expects(static::atLeastOnce())
+            ->method('getType')
+            ->willReturn(DestinationInterface::TYPE_FANOUT);
+
+        $this->exchangeDestinationMock->expects(static::atLeastOnce())
+            ->method('setType')
+            ->with(DestinationInterface::TYPE_FANOUT)
+            ->willReturn($this->exchangeDestinationMock);
+
+        $this->connectionMock->expects(static::atLeastOnce())
+            ->method('createExchange')
+            ->with($this->exchangeDestinationMock)
+            ->willReturn($this->connectionMock);
 
         $this->connectionMock->expects(static::atLeastOnce())
             ->method('createQueueAndBind')
             ->with($this->destinationMock)
             ->willReturn($this->connectionMock);
+
+        $this->destinationMock->expects(static::atLeastOnce())
+            ->method('getName')
+            ->willReturn($this->queueName);
 
         $this->connectionMock->expects(static::atLeastOnce())
             ->method('getChannel')
@@ -141,16 +195,81 @@ class FanoutConsumerTest extends Unit
     /**
      * @return void
      */
+    public function testReceiveMessageWithInvalidDestination(): void
+    {
+        $this->destinationFactoryMock->expects(static::never())
+            ->method('create');
+
+        $this->destinationMock->expects(static::atLeastOnce())
+            ->method('getProperty')
+            ->with('bind')
+            ->willReturn(null);
+
+        $this->destinationMock->expects(static::never())
+            ->method('getType');
+
+        $this->connectionMock->expects(static::never())
+            ->method('createExchange');
+
+        $this->connectionMock->expects(static::never())
+            ->method('createQueueAndBind');
+
+        $this->destinationMock->expects(static::never())
+            ->method('getName');
+
+        $this->connectionMock->expects(static::never())
+            ->method('getChannel');
+
+        $this->messageMapperMock->expects(static::never())
+            ->method('fromJson');
+
+        try {
+            $this->fanoutConsumer->receiveMessage($this->destinationMock);
+            static::fail();
+        } catch (Exception $exception) {}
+    }
+
+    /**
+     * @return void
+     */
     public function testReceiveMessageFromEmptyQueue(): void
     {
+        $this->destinationFactoryMock->expects(static::atLeastOnce())
+            ->method('create')
+            ->willReturn($this->exchangeDestinationMock);
+
         $this->destinationMock->expects(static::atLeastOnce())
-            ->method('getName')
-            ->willReturn($this->queueName);
+            ->method('getProperty')
+            ->with('bind')
+            ->willReturn($this->bind);
+
+        $this->exchangeDestinationMock->expects(static::atLeastOnce())
+            ->method('setName')
+            ->with($this->bind)
+            ->willReturn($this->exchangeDestinationMock);
+
+        $this->destinationMock->expects(static::atLeastOnce())
+            ->method('getType')
+            ->willReturn(DestinationInterface::TYPE_FANOUT);
+
+        $this->exchangeDestinationMock->expects(static::atLeastOnce())
+            ->method('setType')
+            ->with(DestinationInterface::TYPE_FANOUT)
+            ->willReturn($this->exchangeDestinationMock);
+
+        $this->connectionMock->expects(static::atLeastOnce())
+            ->method('createExchange')
+            ->with($this->exchangeDestinationMock)
+            ->willReturn($this->connectionMock);
 
         $this->connectionMock->expects(static::atLeastOnce())
             ->method('createQueueAndBind')
             ->with($this->destinationMock)
             ->willReturn($this->connectionMock);
+
+        $this->destinationMock->expects(static::atLeastOnce())
+            ->method('getName')
+            ->willReturn($this->queueName);
 
         $this->connectionMock->expects(static::atLeastOnce())
             ->method('getChannel')
@@ -181,14 +300,42 @@ class FanoutConsumerTest extends Unit
     {
         $messageMocks = [$this->messageMock];
 
+        $this->destinationFactoryMock->expects(static::atLeastOnce())
+            ->method('create')
+            ->willReturn($this->exchangeDestinationMock);
+
         $this->destinationMock->expects(static::atLeastOnce())
-            ->method('getName')
-            ->willReturn($this->queueName);
+            ->method('getProperty')
+            ->with('bind')
+            ->willReturn($this->bind);
+
+        $this->exchangeDestinationMock->expects(static::atLeastOnce())
+            ->method('setName')
+            ->with($this->bind)
+            ->willReturn($this->exchangeDestinationMock);
+
+        $this->destinationMock->expects(static::atLeastOnce())
+            ->method('getType')
+            ->willReturn(DestinationInterface::TYPE_FANOUT);
+
+        $this->exchangeDestinationMock->expects(static::atLeastOnce())
+            ->method('setType')
+            ->with(DestinationInterface::TYPE_FANOUT)
+            ->willReturn($this->exchangeDestinationMock);
+
+        $this->connectionMock->expects(static::atLeastOnce())
+            ->method('createExchange')
+            ->with($this->exchangeDestinationMock)
+            ->willReturn($this->connectionMock);
 
         $this->connectionMock->expects(static::atLeastOnce())
             ->method('createQueueAndBind')
             ->with($this->destinationMock)
             ->willReturn($this->connectionMock);
+
+        $this->destinationMock->expects(static::atLeastOnce())
+            ->method('getName')
+            ->willReturn($this->queueName);
 
         $this->connectionMock->expects(static::atLeastOnce())
             ->method('getChannel')
@@ -221,14 +368,42 @@ class FanoutConsumerTest extends Unit
     {
         $messageMocks = [$this->messageMock];
 
+        $this->destinationFactoryMock->expects(static::atLeastOnce())
+            ->method('create')
+            ->willReturn($this->exchangeDestinationMock);
+
         $this->destinationMock->expects(static::atLeastOnce())
-            ->method('getName')
-            ->willReturn($this->queueName);
+            ->method('getProperty')
+            ->with('bind')
+            ->willReturn($this->bind);
+
+        $this->exchangeDestinationMock->expects(static::atLeastOnce())
+            ->method('setName')
+            ->with($this->bind)
+            ->willReturn($this->exchangeDestinationMock);
+
+        $this->destinationMock->expects(static::atLeastOnce())
+            ->method('getType')
+            ->willReturn(DestinationInterface::TYPE_FANOUT);
+
+        $this->exchangeDestinationMock->expects(static::atLeastOnce())
+            ->method('setType')
+            ->with(DestinationInterface::TYPE_FANOUT)
+            ->willReturn($this->exchangeDestinationMock);
+
+        $this->connectionMock->expects(static::atLeastOnce())
+            ->method('createExchange')
+            ->with($this->exchangeDestinationMock)
+            ->willReturn($this->connectionMock);
 
         $this->connectionMock->expects(static::atLeastOnce())
             ->method('createQueueAndBind')
             ->with($this->destinationMock)
             ->willReturn($this->connectionMock);
+
+        $this->destinationMock->expects(static::atLeastOnce())
+            ->method('getName')
+            ->willReturn($this->queueName);
 
         $this->connectionMock->expects(static::atLeastOnce())
             ->method('getChannel')

--- a/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/MessageMapperTest.php
+++ b/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/MessageMapperTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Jellyfish\QueueRabbitMq;
 
 use Codeception\Test\Unit;
-use Jellyfish\Queue\Message;
 use Jellyfish\Queue\MessageInterface;
 use Jellyfish\Serializer\SerializerFacadeInterface;
 

--- a/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/MessageTest.php
+++ b/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/MessageTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Jellyfish\Queue;
+namespace Jellyfish\QueueRabbitMq;
 
 use Codeception\Test\Unit;
 

--- a/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/QueueRabbitMqFactoryTest.php
+++ b/packages/queue-rabbit-mq/tests/Jellyfish/QueueRabbitMq/QueueRabbitMqFactoryTest.php
@@ -6,8 +6,6 @@ namespace Jellyfish\QueueRabbitMq;
 
 use Codeception\Test\Unit;
 use Jellyfish\Config\ConfigFacadeInterface;
-use Jellyfish\Queue\Destination;
-use Jellyfish\Queue\Message;
 use Jellyfish\Serializer\SerializerFacadeInterface;
 
 class QueueRabbitMqFactoryTest extends Unit


### PR DESCRIPTION
- add destination factory
- use bind property instead of queue name for exchange name
- move message and destination from contract to implementation
- use better name for exception
- ...