### PR TITLE
✨ Add php > 8.1 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-versions: ["7.4", "8.0"]
+                php-versions: ["7.4", "8.0", "8.1", "8.2"]
         steps:
             - name: Checkout
               uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "dragonmantank/cron-expression": "^v2.0.0 || ^3.0.0",
     "guzzlehttp/guzzle": "^6.0.0 || ^7.0.0",
     "laminas/laminas-diactoros": "^2.0.0",
-    "laminas/laminas-httphandlerrunner": "^1.0.0",
+    "laminas/laminas-httphandlerrunner": "^1.0.0 || ^2.0.0",
     "league/route": "^4.0.0 || ^5.0.0",
     "monolog/monolog": "^2.0.0 <=2.2.0",
     "nyholm/psr7": "^1.0.0",


### PR DESCRIPTION
- add php 8.1 and 8.2 to ci matrix
- allow to install newest version of laminas/laminas-httphandlerrunner
- ...